### PR TITLE
ci: automate creation of GitHub releases and tags

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -2,19 +2,8 @@ name: Release Checker
 
 on:
   pull_request_target:
-    paths: [
-      "dispatch_examples/greeter/Cargo.toml",
-      "frc42_dispatch/Cargo.toml",
-      "frc42_dispatch/hasher/Cargo.toml",
-      "dispatch_examples/greeter/Cargo.toml",
-      "frc42_dispatch/Cargo.toml",
-      "frc42_dispatch/hasher/Cargo.toml",
-      "frc42_dispatch/macros/Cargo.toml",
-      "frc46_token/Cargo.toml",
-      "frc53_nft/Cargo.toml",
-      "fvm_actor_utils/Cargo.toml",
-      "fvm_dispatch_tools/Cargo.toml"
-    ]
+    paths:
+      - "**/Cargo.toml"
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
 
@@ -32,7 +21,6 @@ jobs:
     with:
       sources: |
         [
-          "dispatch_examples/greeter/Cargo.toml",
           "frc42_dispatch/Cargo.toml",
           "frc42_dispatch/hasher/Cargo.toml",
           "frc42_dispatch/macros/Cargo.toml",

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -6,22 +6,14 @@ on:
       "dispatch_examples/greeter/Cargo.toml",
       "frc42_dispatch/Cargo.toml",
       "frc42_dispatch/hasher/Cargo.toml",
+      "dispatch_examples/greeter/Cargo.toml",
+      "frc42_dispatch/Cargo.toml",
+      "frc42_dispatch/hasher/Cargo.toml",
       "frc42_dispatch/macros/Cargo.toml",
-      "frc42_dispatch/macros/example/Cargo.toml",
       "frc46_token/Cargo.toml",
       "frc53_nft/Cargo.toml",
       "fvm_actor_utils/Cargo.toml",
-      "fvm_dispatch_tools/Cargo.toml",
-      "testing/integration/Cargo.toml",
-      "testing/test_actors/Cargo.toml",
-      "testing/test_actors/actors/basic_nft_actor/Cargo.toml",
-      "testing/test_actors/actors/basic_receiving_actor/Cargo.toml",
-      "testing/test_actors/actors/basic_token_actor/Cargo.toml",
-      "testing/test_actors/actors/basic_transfer_actor/Cargo.toml",
-      "testing/test_actors/actors/frc46_factory_actor/Cargo.toml",
-      "testing/test_actors/actors/frc46_test_actor/Cargo.toml",
-      "testing/test_actors/actors/frc53_test_actor/Cargo.toml",
-      "testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml"
+      "fvm_dispatch_tools/Cargo.toml"
     ]
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
@@ -44,19 +36,9 @@ jobs:
           "frc42_dispatch/Cargo.toml",
           "frc42_dispatch/hasher/Cargo.toml",
           "frc42_dispatch/macros/Cargo.toml",
-          "frc42_dispatch/macros/example/Cargo.toml",
           "frc46_token/Cargo.toml",
           "frc53_nft/Cargo.toml",
           "fvm_actor_utils/Cargo.toml",
-          "fvm_dispatch_tools/Cargo.toml",
-          "testing/integration/Cargo.toml",
-          "testing/test_actors/Cargo.toml",
-          "testing/test_actors/actors/basic_nft_actor/Cargo.toml",
-          "testing/test_actors/actors/basic_receiving_actor/Cargo.toml",
-          "testing/test_actors/actors/basic_token_actor/Cargo.toml",
-          "testing/test_actors/actors/basic_transfer_actor/Cargo.toml",
-          "testing/test_actors/actors/frc46_factory_actor/Cargo.toml",
-          "testing/test_actors/actors/frc46_test_actor/Cargo.toml",
-          "testing/test_actors/actors/frc53_test_actor/Cargo.toml",
-          "testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml"
+          "fvm_dispatch_tools/Cargo.toml"
         ]
+      separator: "@"

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,62 @@
+name: Release Checker
+
+on:
+  pull_request_target:
+    paths: [
+      "dispatch_examples/greeter/Cargo.toml",
+      "frc42_dispatch/Cargo.toml",
+      "frc42_dispatch/hasher/Cargo.toml",
+      "frc42_dispatch/macros/Cargo.toml",
+      "frc42_dispatch/macros/example/Cargo.toml",
+      "frc46_token/Cargo.toml",
+      "frc53_nft/Cargo.toml",
+      "fvm_actor_utils/Cargo.toml",
+      "fvm_dispatch_tools/Cargo.toml",
+      "testing/integration/Cargo.toml",
+      "testing/test_actors/Cargo.toml",
+      "testing/test_actors/actors/basic_nft_actor/Cargo.toml",
+      "testing/test_actors/actors/basic_receiving_actor/Cargo.toml",
+      "testing/test_actors/actors/basic_token_actor/Cargo.toml",
+      "testing/test_actors/actors/basic_transfer_actor/Cargo.toml",
+      "testing/test_actors/actors/frc46_factory_actor/Cargo.toml",
+      "testing/test_actors/actors/frc46_test_actor/Cargo.toml",
+      "testing/test_actors/actors/frc53_test_actor/Cargo.toml",
+      "testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml"
+    ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-check:
+    uses: ipdxco/unified-github-workflows/.github/workflows/release-check.yml@v1.0
+    with:
+      sources: |
+        [
+          "dispatch_examples/greeter/Cargo.toml",
+          "frc42_dispatch/Cargo.toml",
+          "frc42_dispatch/hasher/Cargo.toml",
+          "frc42_dispatch/macros/Cargo.toml",
+          "frc42_dispatch/macros/example/Cargo.toml",
+          "frc46_token/Cargo.toml",
+          "frc53_nft/Cargo.toml",
+          "fvm_actor_utils/Cargo.toml",
+          "fvm_dispatch_tools/Cargo.toml",
+          "testing/integration/Cargo.toml",
+          "testing/test_actors/Cargo.toml",
+          "testing/test_actors/actors/basic_nft_actor/Cargo.toml",
+          "testing/test_actors/actors/basic_receiving_actor/Cargo.toml",
+          "testing/test_actors/actors/basic_token_actor/Cargo.toml",
+          "testing/test_actors/actors/basic_transfer_actor/Cargo.toml",
+          "testing/test_actors/actors/frc46_factory_actor/Cargo.toml",
+          "testing/test_actors/actors/frc46_test_actor/Cargo.toml",
+          "testing/test_actors/actors/frc53_test_actor/Cargo.toml",
+          "testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml"
+        ]

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -2,16 +2,8 @@ name: Releaser
 
 on:
   push:
-    paths: [
-      "dispatch_examples/greeter/Cargo.toml",
-      "frc42_dispatch/Cargo.toml",
-      "frc42_dispatch/hasher/Cargo.toml",
-      "frc42_dispatch/macros/Cargo.toml",
-      "frc46_token/Cargo.toml",
-      "frc53_nft/Cargo.toml",
-      "fvm_actor_utils/Cargo.toml",
-      "fvm_dispatch_tools/Cargo.toml"
-    ]
+    paths:
+      - "**/Cargo.toml"
   workflow_dispatch:
 
 permissions:
@@ -27,7 +19,6 @@ jobs:
     with:
       sources: |
         [
-          "dispatch_examples/greeter/Cargo.toml",
           "frc42_dispatch/Cargo.toml",
           "frc42_dispatch/hasher/Cargo.toml",
           "frc42_dispatch/macros/Cargo.toml",

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,0 +1,62 @@
+name: Releaser
+
+on:
+  push:
+    paths: [
+      "dispatch_examples/greeter/Cargo.toml",
+      "frc42_dispatch/Cargo.toml",
+      "frc42_dispatch/hasher/Cargo.toml",
+      "frc42_dispatch/macros/Cargo.toml",
+      "frc42_dispatch/macros/example/Cargo.toml",
+      "frc46_token/Cargo.toml",
+      "frc53_nft/Cargo.toml",
+      "fvm_actor_utils/Cargo.toml",
+      "fvm_dispatch_tools/Cargo.toml",
+      "testing/integration/Cargo.toml",
+      "testing/test_actors/Cargo.toml",
+      "testing/test_actors/actors/basic_nft_actor/Cargo.toml",
+      "testing/test_actors/actors/basic_receiving_actor/Cargo.toml",
+      "testing/test_actors/actors/basic_token_actor/Cargo.toml",
+      "testing/test_actors/actors/basic_transfer_actor/Cargo.toml",
+      "testing/test_actors/actors/frc46_factory_actor/Cargo.toml",
+      "testing/test_actors/actors/frc46_test_actor/Cargo.toml",
+      "testing/test_actors/actors/frc53_test_actor/Cargo.toml",
+      "testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml"
+    ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  releaser:
+    uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
+    with:
+      sources: |
+        [
+          "dispatch_examples/greeter/Cargo.toml",
+          "frc42_dispatch/Cargo.toml",
+          "frc42_dispatch/hasher/Cargo.toml",
+          "frc42_dispatch/macros/Cargo.toml",
+          "frc42_dispatch/macros/example/Cargo.toml",
+          "frc46_token/Cargo.toml",
+          "frc53_nft/Cargo.toml",
+          "fvm_actor_utils/Cargo.toml",
+          "fvm_dispatch_tools/Cargo.toml",
+          "testing/integration/Cargo.toml",
+          "testing/test_actors/Cargo.toml",
+          "testing/test_actors/actors/basic_nft_actor/Cargo.toml",
+          "testing/test_actors/actors/basic_receiving_actor/Cargo.toml",
+          "testing/test_actors/actors/basic_token_actor/Cargo.toml",
+          "testing/test_actors/actors/basic_transfer_actor/Cargo.toml",
+          "testing/test_actors/actors/frc46_factory_actor/Cargo.toml",
+          "testing/test_actors/actors/frc46_test_actor/Cargo.toml",
+          "testing/test_actors/actors/frc53_test_actor/Cargo.toml",
+          "testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml"
+        ]
+    secrets:
+      UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -7,21 +7,10 @@ on:
       "frc42_dispatch/Cargo.toml",
       "frc42_dispatch/hasher/Cargo.toml",
       "frc42_dispatch/macros/Cargo.toml",
-      "frc42_dispatch/macros/example/Cargo.toml",
       "frc46_token/Cargo.toml",
       "frc53_nft/Cargo.toml",
       "fvm_actor_utils/Cargo.toml",
-      "fvm_dispatch_tools/Cargo.toml",
-      "testing/integration/Cargo.toml",
-      "testing/test_actors/Cargo.toml",
-      "testing/test_actors/actors/basic_nft_actor/Cargo.toml",
-      "testing/test_actors/actors/basic_receiving_actor/Cargo.toml",
-      "testing/test_actors/actors/basic_token_actor/Cargo.toml",
-      "testing/test_actors/actors/basic_transfer_actor/Cargo.toml",
-      "testing/test_actors/actors/frc46_factory_actor/Cargo.toml",
-      "testing/test_actors/actors/frc46_test_actor/Cargo.toml",
-      "testing/test_actors/actors/frc53_test_actor/Cargo.toml",
-      "testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml"
+      "fvm_dispatch_tools/Cargo.toml"
     ]
   workflow_dispatch:
 
@@ -42,21 +31,11 @@ jobs:
           "frc42_dispatch/Cargo.toml",
           "frc42_dispatch/hasher/Cargo.toml",
           "frc42_dispatch/macros/Cargo.toml",
-          "frc42_dispatch/macros/example/Cargo.toml",
           "frc46_token/Cargo.toml",
           "frc53_nft/Cargo.toml",
           "fvm_actor_utils/Cargo.toml",
-          "fvm_dispatch_tools/Cargo.toml",
-          "testing/integration/Cargo.toml",
-          "testing/test_actors/Cargo.toml",
-          "testing/test_actors/actors/basic_nft_actor/Cargo.toml",
-          "testing/test_actors/actors/basic_receiving_actor/Cargo.toml",
-          "testing/test_actors/actors/basic_token_actor/Cargo.toml",
-          "testing/test_actors/actors/basic_transfer_actor/Cargo.toml",
-          "testing/test_actors/actors/frc46_factory_actor/Cargo.toml",
-          "testing/test_actors/actors/frc46_test_actor/Cargo.toml",
-          "testing/test_actors/actors/frc53_test_actor/Cargo.toml",
-          "testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml"
+          "fvm_dispatch_tools/Cargo.toml"
         ]
+      separator: "@"
     secrets:
       UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,18 +4,23 @@ This document describes the process for releasing a new version of the `actors-u
 
 ## Current State
 
-1. On a release pull request creation, a [Release Checker](.github/workflows/release-check.yml) workflow will run. It will perform the following actions:
-    1. Extract the version from the modified `Cargo.toml` files. Process each crate in the workspace **independently**.
-    2. Check if a git tag for the version, using the `crate_name@version` as the pattern, already exists. Continue only if it does not.
+1. Create a pull request which updates the [`version` in one or more `Cargo.toml` files](https://github.com/search?q=repo%3Afilecoin-project%2Factors-utils+path%3ACargo.toml+%2F%5Eversion+%3D%2F&type=code).
+   - Title the PR `chore: release Ɑ for Ƅ` where:
+      - `Ɑ` is what is being released like "all crates"
+      - `Ƅ` is the cause for the release like "fvm vX.Y.Z" or "nvXX"
+2. On such a release PR's creation, a [Release Checker](.github/workflows/release-check.yml) workflow will run. It will perform the following actions:
+    1. Extract the version from the modified `Cargo.toml` files, and process each crate in the workspace **independently**.
+    2. Check if a git tag for the version, using the `crate_name@version` as the pattern, already exists, and continue only if it does not.
     3. Create a draft GitHub release with the version as the tag.
     4. Comment on the pull request with a link to the draft release.
 2. **[MANUAL]** Run `cargo publish --dry-run` for each crate that is proposed to be released in the reverse dependency order.
 3. On pull request merge, a [Releaser](.github/workflows/release.yml) workflow will run. It will perform the following actions:
-    1. Extract the version from the modified `Cargo.toml` files. Process each crate in the workspace **independently**.
-    2. Check if a git tag for the version, using the `crate_name@version` as the pattern, already exists. Continue only if it does not.
+    1. Extract the version from the modified `Cargo.toml` files, and process each crate in the workspace **independently**.
+    2. Check if a git tag for the version, using the `crate_name@version` as the pattern, already exists, and continue only if it does not.
     3. Check if a draft GitHub release with the version as the tag exists.
     4. If the draft release exists, publish it. Otherwise, create a new release with the version as the tag.
 4. **[MANUAL]** Run `cargo publish` for each crate that has been released in the reverse dependency order.
+   - You will need to be part of [fvm-create-owners](https://github.com/orgs/filecoin-project/teams/fvm-crate-owners) to do this per https://crates.io/crates/fvm_actor_utils .
 
 #### Known Limitations
 
@@ -24,5 +29,5 @@ This document describes the process for releasing a new version of the `actors-u
 
 #### Possible Improvements
 
-1. Run `cargo publish --dry-run` in the [reverse dependency order](#crate-dependency-graph) automatically. Use a local registry to simulate the dependencies that are not yet published.
+1. Run `cargo publish --dry-run` in the reverse dependency order automatically. Use a local registry to simulate the dependencies that are not yet published.
 2. Run `cargo publish` in the [**reverse dependency order**](#crate-dependency-graph) automatically after the merge.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,28 @@
+# Release Process
+
+This document describes the process for releasing a new version of the `actors-utils` project.
+
+## Current State
+
+1. On a release pull request creation, a [Release Checker](.github/workflows/release-check.yml) workflow will run. It will perform the following actions:
+    1. Extract the version from the modified `Cargo.toml` files. Process each crate in the workspace **independently**.
+    2. Check if a git tag for the version, using the `crate_name@version` as the pattern, already exists. Continue only if it does not.
+    3. Create a draft GitHub release with the version as the tag.
+    4. Comment on the pull request with a link to the draft release.
+2. **[MANUAL]** Run `cargo publish --dry-run` for each crate that is proposed to be released in the reverse dependency order.
+3. On pull request merge, a [Releaser](.github/workflows/release.yml) workflow will run. It will perform the following actions:
+    1. Extract the version from the modified `Cargo.toml` files. Process each crate in the workspace **independently**.
+    2. Check if a git tag for the version, using the `crate_name@version` as the pattern, already exists. Continue only if it does not.
+    3. Check if a draft GitHub release with the version as the tag exists.
+    4. If the draft release exists, publish it. Otherwise, create a new release with the version as the tag.
+4. **[MANUAL]** Run `cargo publish` for each crate that has been released in the reverse dependency order.
+
+#### Known Limitations
+
+1. `cargo publish --dry-run` has to be run manually.
+2. `cargo publish` has to be run manually.
+
+#### Possible Improvements
+
+1. Run `cargo publish --dry-run` in the [reverse dependency order](#crate-dependency-graph) automatically. Use a local registry to simulate the dependencies that are not yet published.
+2. Run `cargo publish` in the [**reverse dependency order**](#crate-dependency-graph) automatically after the merge.


### PR DESCRIPTION
This automates the creation of GitHub releases and associated GitHub tags based on the changes to the version in the Cargo.toml files across the repo. The tags will be prefixed with the directory in which the Cargo.toml file is. For example, changing the version in `dispatch_examples/greeter/Cargo.toml` will create `dispatch_examples/greeter/${VERSION}` tag.

The automation uses the same principles as the one you might know from Go projects where we control the current version via version.json file (https://github.com/ipdxco/unified-github-workflows?tab=readme-ov-file#versioning). This is the exact same workflow just updated to workflow with Cargo.toml.

Note, that the automation doesn't take care of cargo publishing currently.