### PR TITLE
doc: fix indentation, punctuation, and links

### DIFF
--- a/frc42_dispatch/hasher/src/hash.rs
+++ b/frc42_dispatch/hasher/src/hash.rs
@@ -1,15 +1,15 @@
 use thiserror::Error;
 
-/// Minimal interface for a hashing function
+/// Minimal interface for a hashing function.
 ///
-/// Hasher::hash() must return a digest that is at least 4 bytes long so that it can be cast to a
-/// u32
+/// [`Hasher::hash()`] must return a digest that is at least 4 bytes long so that it can be cast to
+/// a [`u32`].
 pub trait Hasher {
-    /// For an input of bytes return a digest that is at least 4 bytes long
+    /// For an input of bytes return a digest that is at least 4 bytes long.
     fn hash(&self, bytes: &[u8]) -> Vec<u8>;
 }
 
-/// Hasher that uses the hash_blake2b syscall provided by the FVM
+/// Hasher that uses the blake2b hash syscall provided by the FVM.
 #[cfg(feature = "use_sdk")]
 #[derive(Default)]
 pub struct Blake2bSyscall {}
@@ -24,7 +24,7 @@ impl Hasher for Blake2bSyscall {
 }
 
 /// Uses an underlying hashing function (blake2b by convention) to generate method numbers from
-/// method names
+/// method names.
 #[derive(Default)]
 pub struct MethodResolver<T: Hasher> {
     hasher: T,
@@ -54,12 +54,12 @@ impl<T: Hasher> MethodResolver<T> {
     const FIRST_METHOD_NUMBER: u64 = 1 << 24;
     const DIGEST_CHUNK_LENGTH: usize = 4;
 
-    /// Creates a MethodResolver with an instance of a hasher (blake2b by convention)
+    /// Creates a [`MethodResolver`] with an instance of a hasher (blake2b by convention).
     pub fn new(hasher: T) -> Self {
         Self { hasher }
     }
 
-    /// Generates a standard FRC-0042 compliant method number
+    /// Generates a standard FRC-0042 compliant method number.
     ///
     /// The method number is calculated as the first four bytes of `hash(method-name)`.
     /// The name `Constructor` is always hashed to 1 and other method names that hash to
@@ -91,10 +91,10 @@ impl<T: Hasher> MethodResolver<T> {
     }
 }
 
-/// Checks that a method name is valid and compliant with the FRC-0042 standard recommendations
+/// Checks that a method name is valid and compliant with the FRC-0042 standard recommendations.
 ///
-/// - Only ASCII characters in `[a-zA-Z0-9_]` are allowed
-/// - Starts with a character in `[A-Z_]`
+/// - Only ASCII characters in `[a-zA-Z0-9_]` are allowed.
+/// - Starts with a character in `[A-Z_]`.
 fn check_method_name(method_name: &str) -> Result<(), MethodNameErr> {
     if method_name.is_empty() {
         return Err(MethodNameErr::EmptyString);
@@ -114,10 +114,11 @@ fn check_method_name(method_name: &str) -> Result<(), MethodNameErr> {
     Ok(())
 }
 
-/// Takes a byte array and interprets it as a u32 number
+/// Takes a byte array and interprets it as a u32 number.
 ///
 /// Using big-endian order interperets the first four bytes to an int.
-/// The slice passed to this must be at least length 4
+///
+/// The slice passed to this must be at least length 4.
 fn as_u32(bytes: &[u8]) -> u32 {
     u32::from_be_bytes(bytes[0..4].try_into().expect("bytes was not at least length 4"))
 }
@@ -171,7 +172,7 @@ mod tests {
         );
     }
 
-    /// Fake hasher that always returns a digest beginning with b"\0\0\0\0"
+    /// Fake hasher that always returns a digest beginning with b"\0\0\0\0".
     #[derive(Clone, Copy)]
     struct FakeHasher0 {}
     impl Hasher for FakeHasher0 {
@@ -183,7 +184,7 @@ mod tests {
         }
     }
 
-    /// Fake hasher that always returns a digest beginning with b"\0\0\0\1"
+    /// Fake hasher that always returns a digest beginning with b"\0\0\0\1".
     #[derive(Clone, Copy)]
     struct FakeHasher1 {}
     impl Hasher for FakeHasher1 {

--- a/frc42_dispatch/macros/src/lib.rs
+++ b/frc42_dispatch/macros/src/lib.rs
@@ -10,7 +10,7 @@ use crate::hash::Blake2bHasher;
 struct MethodName(LitStr);
 
 impl MethodName {
-    /// Hash the method name
+    /// Hash the method name.
     fn hash(&self) -> u64 {
         let resolver = MethodResolver::new(Blake2bHasher {});
         resolver.method_number(&self.0.value()).unwrap()

--- a/frc42_dispatch/src/message.rs
+++ b/frc42_dispatch/src/message.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::hash::{Hasher, MethodNameErr, MethodResolver};
 
-/// Utility to invoke standard methods on deployed actors
+/// Utility to invoke standard methods on deployed actors.
 #[derive(Default)]
 pub struct MethodMessenger<T: Hasher> {
     method_resolver: MethodResolver<T>,
@@ -21,13 +21,13 @@ pub enum MethodMessengerError {
 }
 
 impl<T: Hasher> MethodMessenger<T> {
-    /// Creates a new method messenger using a specified hashing function (blake2b by default)
+    /// Creates a new method messenger using a specified hashing function (blake2b by default).
     pub fn new(hasher: T) -> Self {
         Self { method_resolver: MethodResolver::new(hasher) }
     }
 
     /// Calls a method (by name) on a specified actor by constructing and publishing the underlying
-    /// on-chain Message
+    /// on-chain message.
     #[cfg(feature = "use_sdk")]
     pub fn call_method(
         &self,

--- a/frc46_token/src/receiver.rs
+++ b/frc46_token/src/receiver.rs
@@ -15,7 +15,7 @@ pub trait FRC46ReceiverHook<T: RecipientData> {
 }
 
 impl<T: RecipientData> FRC46ReceiverHook<T> for ReceiverHook<T> {
-    /// Construct a new FRC46 ReceiverHook call
+    /// Construct a new FRC46 [`ReceiverHook`] call.
     fn new_frc46(
         address: Address,
         frc46_params: FRC46TokenReceived,
@@ -30,19 +30,19 @@ impl<T: RecipientData> FRC46ReceiverHook<T> for ReceiverHook<T> {
     }
 }
 
-/// Receive parameters for an FRC46 token
+/// Receive parameters for an FRC46 token.
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 pub struct FRC46TokenReceived {
-    /// The account that the tokens are being pulled from (the token actor address itself for mint)
+    /// The account that the tokens are being pulled from (the token actor address itself for mint).
     pub from: ActorID,
-    /// The account that the tokens are being sent to (the receiver address)
+    /// The account that the tokens are being sent to (the receiver address).
     pub to: ActorID,
-    /// Address of the operator that initiated the transfer/mint
+    /// Address of the operator that initiated the transfer/mint.
     pub operator: ActorID,
-    /// Amount of tokens being transferred/minted
+    /// Amount of tokens being transferred/minted.
     pub amount: TokenAmount,
-    /// Data specified by the operator during transfer/mint
+    /// Data specified by the operator during transfer/mint.
     pub operator_data: RawBytes,
-    /// Additional data specified by the token-actor during transfer/mint
+    /// Additional data specified by the token-actor during transfer/mint.
     pub token_data: RawBytes,
 }

--- a/frc46_token/src/token/types.rs
+++ b/frc46_token/src/token/types.rs
@@ -5,20 +5,20 @@ use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 
 /// A standard fungible token interface allowing for on-chain transactions that implements the
-/// FRC-0046 standard. This represents the external interface exposed to other on-chain actors
+/// FRC-0046 standard. This represents the external interface exposed to other on-chain actors.
 ///
 /// Token authors must implement this trait and link the methods to standard dispatch numbers (as
 /// defined by [FRC-0042](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md)).
 pub trait FRC46Token {
     type TokenError;
-    /// Returns the name of the token
+    /// Returns the name of the token.
     ///
-    /// Must not be empty
+    /// Must not be empty.
     fn name(&self) -> String;
 
-    /// Returns the ticker symbol of the token
+    /// Returns the ticker symbol of the token.
     ///
-    /// Must not be empty. Should be a short uppercase string
+    /// Must not be empty. Should be a short uppercase string.
     fn symbol(&self) -> String;
 
     /// Returns the smallest amount of tokens which is indivisible.
@@ -30,18 +30,18 @@ pub trait FRC46Token {
     /// A granularity of 10^18 corresponds to whole units only, with no further decimal precision.
     fn granularity(&self) -> GranularityReturn;
 
-    /// Returns the total amount of the token in existence
+    /// Returns the total amount of the token in existence.
     ///
     /// Must be non-negative. The total supply must equal the balances of all addresses. The total
     /// supply should equal the sum of all minted tokens less the sum of all burnt tokens.
     fn total_supply(&mut self) -> TotalSupplyReturn;
 
-    /// Returns the balance of an address
+    /// Returns the balance of an address.
     ///
     /// Balance is always non-negative. Uninitialised addresses have an implicit zero balance.
     fn balance_of(&mut self, params: Address) -> Result<BalanceReturn, Self::TokenError>;
 
-    /// Returns the allowance approved for an operator on a spender's balance
+    /// Returns the allowance approved for an operator on a spender's balance.
     ///
     /// The operator can burn or transfer the allowance amount out of the owner's address.
     fn allowance(
@@ -49,14 +49,14 @@ pub trait FRC46Token {
         params: GetAllowanceParams,
     ) -> Result<AllowanceReturn, Self::TokenError>;
 
-    /// Transfers tokens from the caller to another address
+    /// Transfers tokens from the caller to another address.
     ///
     /// Amount must be non-negative (but can be zero). Transferring to the caller's own address must
     /// be treated as a normal transfer. Must call the receiver hook on the receiver's address,
     /// failing and aborting the transfer if calling the hook fails or aborts.
     fn transfer(&mut self, params: TransferParams) -> Result<TransferReturn, Self::TokenError>;
 
-    /// Transfers tokens from one address to another
+    /// Transfers tokens from one address to another.
     ///
     /// The caller must have previously approved to control at least the sent amount. If successful,
     /// the amount transferred is deducted from the caller's allowance.
@@ -66,7 +66,7 @@ pub trait FRC46Token {
     ) -> Result<TransferFromReturn, Self::TokenError>;
 
     /// Atomically increases the approved allowance that a operator can transfer/burn from the
-    /// caller's balance
+    /// caller's balance.
     ///
     /// The increase must be non-negative. Returns the new total allowance approved for that
     /// owner-operator pair.
@@ -75,8 +75,8 @@ pub trait FRC46Token {
         params: IncreaseAllowanceParams,
     ) -> Result<IncreaseAllowanceReturn, Self::TokenError>;
 
-    /// Atomically decreases the approved balance that a operator can transfer/burn from the caller's
-    /// balance
+    /// Atomically decreases the approved balance that a operator can transfer/burn from the
+    /// caller's balance.
     ///
     /// The decrease must be non-negative. Sets the allowance to zero if the decrease is greater
     /// than the currently approved allowance. Returns the new total allowance approved for that
@@ -86,16 +86,16 @@ pub trait FRC46Token {
         params: DecreaseAllowanceParams,
     ) -> Result<DecreaseAllowanceReturn, Self::TokenError>;
 
-    /// Sets the allowance a operator has on the owner's account to zero
+    /// Sets the allowance a operator has on the owner's account to zero.
     fn revoke_allowance(
         &mut self,
         params: RevokeAllowanceParams,
     ) -> Result<RevokeAllowanceReturn, Self::TokenError>;
 
-    /// Burns tokens from the caller's balance, decreasing the total supply
+    /// Burns tokens from the caller's balance, decreasing the total supply.
     fn burn(&mut self, params: BurnParams) -> Result<BurnReturn, Self::TokenError>;
 
-    /// Burns tokens from an address's balance
+    /// Burns tokens from an address's balance.
     ///
     /// The caller must have been previously approved to control at least the burnt amount.
     fn burn_from(&mut self, params: BurnFromParams) -> Result<BurnFromReturn, Self::TokenError>;
@@ -110,24 +110,25 @@ pub type DecreaseAllowanceReturn = TokenAmount;
 pub type RevokeAllowanceReturn = ();
 
 /// Return value after a successful mint.
+///
 /// The mint method is not standardised, so this is merely a useful library-level type,
 /// and recommendation for token implementations.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct MintReturn {
-    /// The new balance of the owner address
+    /// The new balance of the owner address.
     pub balance: TokenAmount,
     /// The new total supply.
     pub supply: TokenAmount,
-    /// (Optional) data returned from receiver hook
+    /// (Optional) data returned from receiver hook.
     pub recipient_data: RawBytes,
 }
 
-/// Intermediate data used by mint_return to construct the return data
+/// Intermediate data used by mint_return to construct the return data.
 #[derive(Clone, Debug)]
 pub struct MintIntermediate {
-    /// Recipient address to use for querying balance
+    /// Recipient address to use for querying balance.
     pub recipient: Address,
-    /// (Optional) data returned from receiver hook
+    /// (Optional) data returned from receiver hook.
     pub recipient_data: RawBytes,
 }
 
@@ -137,33 +138,33 @@ impl RecipientData for MintIntermediate {
     }
 }
 
-/// Instruction to transfer tokens to another address
+/// Instruction to transfer tokens to another address.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct TransferParams {
     pub to: Address,
-    /// A non-negative amount to transfer
+    /// A non-negative amount to transfer.
     pub amount: TokenAmount,
-    /// Arbitrary data to pass on via the receiver hook
+    /// Arbitrary data to pass on via the receiver hook.
     pub operator_data: RawBytes,
 }
 
-/// Return value after a successful transfer
+/// Return value after a successful transfer.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct TransferReturn {
-    /// The new balance of the `from` address
+    /// The new balance of the `from` address.
     pub from_balance: TokenAmount,
-    /// The new balance of the `to` address
+    /// The new balance of the `to` address.
     pub to_balance: TokenAmount,
-    /// (Optional) data returned from receiver hook
+    /// (Optional) data returned from receiver hook.
     pub recipient_data: RawBytes,
 }
 
-/// Intermediate data used by transfer_return to construct the return data
+/// Intermediate data used by transfer_return to construct the return data.
 #[derive(Debug)]
 pub struct TransferIntermediate {
     pub from: Address,
     pub to: Address,
-    /// (Optional) data returned from receiver hook
+    /// (Optional) data returned from receiver hook.
     pub recipient_data: RawBytes,
 }
 
@@ -173,37 +174,37 @@ impl RecipientData for TransferIntermediate {
     }
 }
 
-/// Instruction to transfer tokens between two addresses as an operator
+/// Instruction to transfer tokens between two addresses as an operator.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct TransferFromParams {
     pub from: Address,
     pub to: Address,
-    /// A non-negative amount to transfer
+    /// A non-negative amount to transfer.
     pub amount: TokenAmount,
-    /// Arbitrary data to pass on via the receiver hook
+    /// Arbitrary data to pass on via the receiver hook.
     pub operator_data: RawBytes,
 }
 
-/// Return value after a successful delegated transfer
+/// Return value after a successful delegated transfer.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct TransferFromReturn {
-    /// The new balance of the `from` address
+    /// The new balance of the `from` address.
     pub from_balance: TokenAmount,
-    /// The new balance of the `to` address
+    /// The new balance of the `to` address.
     pub to_balance: TokenAmount,
-    /// The new remaining allowance between `owner` and `operator` (caller)
+    /// The new remaining allowance between `owner` and `operator` (caller).
     pub allowance: TokenAmount,
-    /// (Optional) data returned from receiver hook
+    /// (Optional) data returned from receiver hook.
     pub recipient_data: RawBytes,
 }
 
-/// Intermediate data used by transfer_from_return to construct the return data
+/// Intermediate data used by transfer_from_return to construct the return data.
 #[derive(Clone, Debug)]
 pub struct TransferFromIntermediate {
     pub operator: Address,
     pub from: Address,
     pub to: Address,
-    /// (Optional) data returned from receiver hook
+    /// (Optional) data returned from receiver hook.
     pub recipient_data: RawBytes,
 }
 
@@ -213,62 +214,62 @@ impl RecipientData for TransferFromIntermediate {
     }
 }
 
-/// Instruction to increase an allowance between two addresses
+/// Instruction to increase an allowance between two addresses.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct IncreaseAllowanceParams {
     pub operator: Address,
-    /// A non-negative amount to increase the allowance by
+    /// A non-negative amount to increase the allowance by.
     pub increase: TokenAmount,
 }
 
-/// Instruction to decrease an allowance between two addresses
+/// Instruction to decrease an allowance between two addresses.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct DecreaseAllowanceParams {
     pub operator: Address,
-    /// A non-negative amount to decrease the allowance by
+    /// A non-negative amount to decrease the allowance by.
     pub decrease: TokenAmount,
 }
 
-/// Instruction to revoke (set to 0) an allowance
+/// Instruction to revoke (set to 0) an allowance.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct RevokeAllowanceParams {
     pub operator: Address,
 }
 
-/// Params to get allowance between to addresses
+/// Params to get allowance between to addresses.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct GetAllowanceParams {
     pub owner: Address,
     pub operator: Address,
 }
 
-/// Instruction to burn an amount of tokens
+/// Instruction to burn an amount of tokens.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct BurnParams {
-    /// A non-negative amount to burn
+    /// A non-negative amount to burn.
     pub amount: TokenAmount,
 }
 
-/// The updated value after burning
+/// The updated value after burning.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct BurnReturn {
-    /// New balance in the account after the successful burn
+    /// New balance in the account after the successful burn.
     pub balance: TokenAmount,
 }
 
-/// Instruction to burn an amount of tokens from another address
+/// Instruction to burn an amount of tokens from another address.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct BurnFromParams {
     pub owner: Address,
-    /// A non-negative amount to burn
+    /// A non-negative amount to burn.
     pub amount: TokenAmount,
 }
 
-/// The updated value after a delegated burn
+/// The updated value after a delegated burn.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct BurnFromReturn {
-    /// New balance in the account after the successful burn
+    /// New balance in the account after the successful burn.
     pub balance: TokenAmount,
-    /// New remaining allowance between the owner and operator (caller)
+    /// New remaining allowance between the owner and operator (caller).
     pub allowance: TokenAmount,
 }

--- a/frc53_nft/src/lib.rs
+++ b/frc53_nft/src/lib.rs
@@ -45,7 +45,7 @@ pub enum NFTError {
 
 pub type Result<T> = std::result::Result<T, NFTError>;
 
-/// A helper handle for NFTState that injects services into the state-level operations
+/// A helper handle for NFTState that injects services into the state-level operations.
 pub struct NFT<'st, S, BS>
 where
     S: Syscalls,
@@ -60,18 +60,20 @@ where
     S: Syscalls,
     BS: Blockstore,
 {
-    /// Wrap an instance of the state-tree in a handle for higher-level operations
+    /// Wrap an instance of the state-tree in a handle for higher-level operations.
     pub fn wrap(runtime: ActorRuntime<S, BS>, state: &'st mut NFTState) -> Self {
         Self { runtime, state }
     }
 
-    /// Flush state and return Cid for root
+    /// Flush state and return Cid for root.
     pub fn flush(&mut self) -> Result<Cid> {
         Ok(self.state.save(&self.runtime)?)
     }
 
-    /// Loads a fresh copy of the state from a blockstore from a given cid, replacing existing state
-    /// The old state is returned for convenience but can be safely dropped
+    /// Loads a fresh copy of the state from a blockstore from a given cid, replacing existing
+    /// state.
+    ///
+    /// The old state is returned for convenience but can be safely dropped.
     pub fn load_replace(&mut self, cid: &Cid) -> Result<NFTState> {
         let new_state = NFTState::load(&self.runtime, cid)?;
         Ok(std::mem::replace(self.state, new_state))
@@ -82,8 +84,8 @@ where
     ///
     /// If errors are returned by any intermediate state method, it is recommended to abort the
     /// entire transaction by propagating the error. If state-level errors are explicitly handled,
-    /// it is necessary to reload from the blockstore any passed-in owner HAMT or token AMT to ensure
-    /// partial writes are dropped.
+    /// it is necessary to reload from the blockstore any passed-in owner HAMT or token AMT to
+    /// ensure partial writes are dropped.
     ///
     /// If the closure returns an error, the transaction is dropped atomically and no change is
     /// observed on token state.
@@ -98,7 +100,7 @@ where
         Ok(res)
     }
 
-    /// Check the underlying state for consistency errors
+    /// Check the underlying state for consistency errors.
     pub fn check_invariants(&self) -> std::result::Result<StateSummary, Vec<StateInvariantError>> {
         let (summary, errors) = self.state.check_invariants(&self.runtime);
         if errors.is_empty() {
@@ -114,12 +116,12 @@ where
     S: Syscalls,
     BS: Blockstore,
 {
-    /// Return the total number of NFTs in circulation from this collection
+    /// Return the total number of NFTs in circulation from this collection.
     pub fn total_supply(&self) -> u64 {
         self.state.total_supply
     }
 
-    /// Return the number of NFTs held by a particular address
+    /// Return the number of NFTs held by a particular address.
     pub fn balance_of(&self, address: &Address) -> Result<u64> {
         let balance = match self.runtime.resolve_id(address) {
             Ok(owner) => self.state.get_balance(&self.runtime, owner)?,
@@ -129,23 +131,23 @@ where
         Ok(balance)
     }
 
-    /// Return the owner of an NFT
+    /// Return the owner of an NFT.
     pub fn owner_of(&self, token_id: TokenID) -> Result<ActorID> {
         Ok(self.state.get_owner(&self.runtime, token_id)?)
     }
 
-    /// Return the metadata for an NFT
+    /// Return the metadata for an NFT.
     pub fn metadata(&self, token_id: TokenID) -> Result<String> {
         Ok(self.state.get_metadata(&self.runtime, token_id)?)
     }
 
     /// Create new NFTs belonging to the initial_owner. The mint method is not standardised
-    /// as part of the actor's interface but this is a usefuly method at the library level to
+    /// as part of the actor's interface but this is a useful method at the library level to
     /// generate new tokens that will maintain the necessary state invariants.
     ///
     /// For each string in metadata_array, a new NFT will be minted with the given metadata.
     ///
-    /// Returns a MintIntermediate that can be used to construct return data
+    /// Returns a [`MintIntermediate`] that can be used to construct return data.
     pub fn mint(
         &mut self,
         operator: &Address,
@@ -174,10 +176,10 @@ where
             .map_err(StateError::from)?)
     }
 
-    /// Constructs MintReturn data from a MintIntermediate handle
+    /// Constructs MintReturn data from a MintIntermediate handle.
     ///
     /// Creates an up-to-date view of the actor state where necessary to generate the values
-    /// `prior_state_cid` is the CID of the state prior to hook call
+    /// `prior_state_cid` is the CID of the state prior to hook call.
     pub fn mint_return(
         &mut self,
         intermediate: MintIntermediate,
@@ -187,9 +189,9 @@ where
         Ok(self.state.mint_return(&self.runtime, intermediate)?)
     }
 
-    /// Burn a set of NFTs as the owner and returns the resulting balance
+    /// Burn a set of NFTs as the owner and returns the resulting balance.
     ///
-    /// A burnt TokenID can never be minted again
+    /// A burnt [`TokenID`] can never be minted again.
     pub fn burn(&mut self, owner: &Address, token_ids: &[TokenID]) -> Result<u64> {
         let owner = self.runtime.resolve_id(owner)?;
 
@@ -202,9 +204,9 @@ where
         Ok(balance)
     }
 
-    /// Burn a set of NFTs as an operator and returns the resulting balance
+    /// Burn a set of NFTs as an operator and returns the resulting balance.
     ///
-    /// A burnt TokenID can never be minted again
+    /// A burnt [`TokenID`] can never be minted again.
     pub fn burn_from(
         &mut self,
         owner: &Address,
@@ -235,10 +237,10 @@ where
         Ok(balance)
     }
 
-    /// Approve an operator to transfer or burn a single NFT
+    /// Approve an operator to transfer or burn a single NFT.
     ///
-    /// `caller` may be an account-level operator or owner of the NFT
-    /// `operator` is the new address to become an approved operator
+    /// - `caller` may be an account-level operator or owner of the NFT.
+    /// - `operator` is the new address to become an approved operator.
     pub fn approve(
         &mut self,
         caller: &Address,
@@ -258,10 +260,10 @@ where
         Ok(())
     }
 
-    /// Revoke the approval of an operator to transfer a particular NFT
+    /// Revoke the approval of an operator to transfer a particular NFT.
     ///
-    /// `caller` may be an account-level operator or owner of the NFT
-    /// `operator` is the address whose approval is being revoked
+    /// - `caller` may be an account-level operator or owner of the NFT.
+    /// - `operator` is the address whose approval is being revoked.
     pub fn revoke(
         &mut self,
         caller: &Address,
@@ -284,10 +286,10 @@ where
         Ok(())
     }
 
-    /// Approve an operator to transfer or burn on behalf of the account
+    /// Approve an operator to transfer or burn on behalf of the account.
     ///
-    /// `owner` must be the address that called this method
-    /// `operator` is the new address to become an approved operator
+    /// - `owner` must be the address that called this method.
+    /// - `operator` is the new address to become an approved operator.
     pub fn approve_for_owner(&mut self, owner: &Address, operator: &Address) -> Result<()> {
         let owner = self.runtime.resolve_id(owner)?;
         // Attempt to instantiate the accounts if they don't exist
@@ -298,10 +300,10 @@ where
         Ok(())
     }
 
-    /// Revoke the approval of an operator to transfer on behalf of the caller
+    /// Revoke the approval of an operator to transfer on behalf of the caller.
     ///
-    /// `owner` must be the address that called this method
-    /// `operator` is the address whose approval is being revoked
+    /// - `owner` must be the address that called this method.
+    /// - `operator` is the address whose approval is being revoked.
     pub fn revoke_for_all(&mut self, owner: &Address, operator: &Address) -> Result<()> {
         let owner = self.runtime.resolve_id(owner)?;
         let operator = match self.runtime.resolve_id(operator) {
@@ -314,7 +316,7 @@ where
         Ok(())
     }
 
-    /// Transfers a token owned by the caller
+    /// Transfers a token owned by the caller.
     pub fn transfer(
         &mut self,
         owner: &Address,
@@ -344,10 +346,10 @@ where
         Ok(ReceiverHook::new_frc53(*recipient, params, intermediate).map_err(StateError::from)?)
     }
 
-    /// Constructs TransferReturn data from a TransferIntermediate
+    /// Constructs [`TransferReturn`] data from a [`TransferIntermediate`].
     ///
     /// Creates an up-to-date view of the actor state where necessary to generate the values
-    /// `prior_state_cid` is the CID of the state prior to hook call
+    /// `prior_state_cid` is the CID of the state prior to hook call.
     pub fn transfer_return(
         &mut self,
         intermediate: TransferIntermediate,
@@ -357,7 +359,7 @@ where
         Ok(self.state.transfer_return(&self.runtime, intermediate)?)
     }
 
-    /// Transfers a token that the caller is an operator for
+    /// Transfers a token that the caller is an operator for.
     pub fn transfer_from(
         &mut self,
         owner: &Address,
@@ -404,10 +406,10 @@ where
         Ok(ReceiverHook::new_frc53(*recipient, params, intermediate).map_err(StateError::from)?)
     }
 
-    /// Constructs TransferReturn data from a TransferIntermediate
+    /// Constructs [`TransferReturn`] data from a [`TransferIntermediate`].
     ///
     /// Creates an up-to-date view of the actor state where necessary to generate the values
-    /// `prior_state_cid` is the CID of the state prior to hook call
+    /// `prior_state_cid` is the CID of the state prior to hook call.
     pub fn transfer_from_return(
         &mut self,
         intermediate: TransferIntermediate,
@@ -417,7 +419,7 @@ where
         Ok(self.state.transfer_return(&self.runtime, intermediate)?)
     }
 
-    /// Enumerates a page of TokenIDs
+    /// Enumerates a page of [`TokenID`]s.
     pub fn list_tokens(&self, cursor: RawBytes, limit: u64) -> Result<ListTokensReturn> {
         let cursor = Cursor::from_bytes(cursor)?;
         let (tokens, next_cursor) = self.state.list_tokens(&self.runtime, cursor, limit)?;
@@ -425,7 +427,7 @@ where
         Ok(ListTokensReturn { tokens, next_cursor })
     }
 
-    /// Enumerates a page of TokenIDs owned by a specific address
+    /// Enumerates a page of [`TokenID`]s. owned by a specific address.
     pub fn list_owned_tokens(
         &self,
         owner: &Address,
@@ -440,7 +442,7 @@ where
         Ok(ListTokensReturn { tokens, next_cursor })
     }
 
-    /// Returns all the operators approved by an owner for a token
+    /// Returns all the operators approved by an owner for a token.
     pub fn list_token_operators(
         &self,
         token_id: TokenID,
@@ -454,7 +456,7 @@ where
         Ok(ListTokenOperatorsReturn { operators, next_cursor })
     }
 
-    /// Enumerates tokens for which an account is an operator for an owner
+    /// Enumerates tokens for which an account is an operator for an owner.
     pub fn list_operator_tokens(
         &self,
         operator: &Address,
@@ -469,7 +471,7 @@ where
         Ok(ListOperatorTokensReturn { tokens, next_cursor })
     }
 
-    /// Returns all the account-level operators approved by an owner
+    /// Returns all the account-level operators approved by an owner.
     pub fn list_account_operators(
         &self,
         owner: &Address,
@@ -484,10 +486,11 @@ where
         Ok(ListAccountOperatorsReturn { operators, next_cursor })
     }
 
-    /// Reloads the state if the current root cid has diverged (i.e. during re-entrant receiver hooks)
-    /// from the last known expected cid
+    /// Reloads the state if the current root cid has diverged (i.e. during re-entrant receiver
+    /// hooks) from the last known expected cid.
     ///
-    /// Returns the current in-blockstore state if the root cid has changed else RawBytes::default()
+    /// Returns the current in-blockstore state if the root cid has changed else
+    /// [`RawBytes::default()`].
     pub fn reload_if_changed(&mut self, expected_cid: Cid) -> Result<Option<NFTState>> {
         let current_cid = self.runtime.root_cid()?;
         if current_cid != expected_cid {
@@ -500,7 +503,7 @@ where
 }
 
 impl Cursor {
-    /// Generates a cursor from an opaque representation
+    /// Generates a cursor from an opaque representation.
     pub fn from_bytes(bytes: RawBytes) -> Result<Option<Cursor>> {
         if bytes.is_empty() {
             Ok(None)
@@ -509,7 +512,7 @@ impl Cursor {
         }
     }
 
-    /// Generates an opaque representation of the cursor that can be used to resume enumeration
+    /// Generates an opaque representation of the cursor that can be used to resume enumeration.
     pub fn to_bytes(&self) -> Result<RawBytes> {
         Ok(RawBytes::from(fvm_ipld_encoding::to_vec(self)?))
     }

--- a/frc53_nft/src/receiver.rs
+++ b/frc53_nft/src/receiver.rs
@@ -17,7 +17,7 @@ pub trait FRC53ReceiverHook<T: RecipientData> {
 }
 
 impl<T: RecipientData> FRC53ReceiverHook<T> for ReceiverHook<T> {
-    /// Construct a new FRC46 ReceiverHook call
+    /// Construct a new FRC46 [`ReceiverHook`] call.
     fn new_frc53(
         address: Address,
         frc53_params: FRC53TokenReceived,
@@ -32,17 +32,17 @@ impl<T: RecipientData> FRC53ReceiverHook<T> for ReceiverHook<T> {
     }
 }
 
-/// Receive parameters for an FRC53 token
+/// Receive parameters for an FRC53 token.
 #[derive(Serialize_tuple, Deserialize_tuple, PartialEq, Eq, Clone, Debug)]
 pub struct FRC53TokenReceived {
-    /// The account that the tokens are being sent to (the receiver address)
+    /// The account that the tokens are being sent to (the receiver address).
     pub to: ActorID,
-    /// Address of the operator that initiated the transfer/mint
+    /// Address of the operator that initiated the transfer/mint.
     pub operator: ActorID,
-    /// Amount of tokens being transferred/minted
+    /// Amount of tokens being transferred/minted.
     pub token_ids: Vec<TokenID>,
-    /// Data specified by the operator during transfer/mint
+    /// Data specified by the operator during transfer/mint.
     pub operator_data: RawBytes,
-    /// Additional data specified by the token-actor during transfer/mint
+    /// Additional data specified by the token-actor during transfer/mint.
     pub token_data: RawBytes,
 }

--- a/frc53_nft/src/types.rs
+++ b/frc53_nft/src/types.rs
@@ -7,87 +7,94 @@ use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::ActorID;
 
+#[cfg(doc)]
+use super::state::Cursor;
+
 pub type TokenID = u64;
 
 /// Multiple token IDs are represented as a BitField encoded with RLE+ the index of each set bit
-/// corresponds to a TokenID
+/// corresponds to a TokenID.
 pub type TokenSet = BitField;
 
 /// Multiple actor IDs are represented as a BitField encoded with RLE+ the index of each set bit
-/// corresponds to a ActorID
+/// corresponds to a ActorID.
 pub type ActorIDSet = BitField;
 
-/// A trait to be implemented by FRC-0053 compliant actors
+/// A trait to be implemented by FRC-0053 compliant actors.
 pub trait FRC53NFT {
-    /// A descriptive name for the collection of NFTs in this actor
+    /// A descriptive name for the collection of NFTs in this actor.
     fn name(&self) -> String;
 
-    /// An abbreviated name for NFTs in this contract
+    /// An abbreviated name for NFTs in this contract.
     fn symbol(&self) -> String;
 
-    /// Gets a link to associated metadata for a given NFT
+    /// Gets a link to associated metadata for a given NFT.
     fn metadata(&self, params: TokenID) -> Cid;
 
-    /// Gets the total number of NFTs in this actor
+    /// Gets the total number of NFTs in this actor.
     fn total_supply(&self) -> u64;
 
     /// Burns a given NFT, removing it from the total supply and preventing new NFTs from being
-    /// minted with the same ID
-    fn burn(&self, params: TokenID);
+    /// minted with the same ID.
+    fn burn(&self, token_id: TokenID);
 
-    /// Gets a list of all the tokens in the collection
-    /// FIXME: make this paginated
+    /// Gets a list of all the tokens in the collection.
+    // FIXME: make this paginated
     fn list_tokens(&self) -> Vec<TokenID>;
 
-    /// Gets the number of tokens held by a particular address (if it exists)
-    fn balance_of(&self, params: Address) -> u64;
+    /// Gets the number of tokens held by a particular address (if it exists).
+    fn balance_of(&self, owner: Address) -> u64;
 
-    /// Returns the owner of the NFT specified by `token_id`
-    fn owner_of(&self, params: TokenID) -> ActorID;
+    /// Returns the owner of the NFT specified by `token_id`.
+    fn owner_of(&self, token_id: TokenID) -> ActorID;
 
-    /// Transfers specific NFTs from the caller to another account
+    /// Transfers specific NFTs from the caller to another account.
     fn transfer(&self, params: TransferParams);
 
-    /// Transfers specific NFTs between the `from` and `to` addresses
+    /// Transfers specific NFTs between the [`from`][`TransferFromParams::from`] and
+    /// [`to`][`TransferFromParams::to`] addresses.
     fn transfer_from(&self, params: TransferFromParams);
 
-    /// Change or reaffirm the approved address for a set of NFTs, setting to zero means there is no approved address
+    /// Change or reaffirm the approved address for a set of NFTs, setting to zero means there is no
+    /// approved address.
     fn approve(&self, params: ApproveParams);
 
-    /// Set approval for all, allowing an operator to control all of the caller's tokens (including future tokens)
-    /// until approval is revoked
+    /// Set approval for all, allowing an operator to control all of the caller's tokens (including
+    /// future tokens) until approval is revoked.
     fn set_approval_for_all(&self, params: ApproveForAllParams);
 
-    /// Get the approved address for a single NFT
+    /// Get the approved address for a single NFT.
     fn get_approved(&self, params: TokenID) -> ActorID;
 
-    /// Query if the address is the approved operator for another address
+    /// Query if the address is the approved operator for another address.
     fn is_approved_for_all(&self, params: IsApprovedForAllParams) -> bool;
 }
 
-/// Return value after a successful mint
+/// Return value after a successful mint.
+///
 /// The mint method is not standardised, so this is merely a useful library-level type, and
-/// recommendation for token implementations
+/// recommendation for token implementations.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct MintReturn {
-    /// The new balance of the owner address
+    /// The new balance of the owner address.
     pub balance: u64,
-    /// The new total supply
+    /// The new total supply.
     pub supply: u64,
-    /// List of the tokens that were minted successfully (some may have been burned during hook execution)
+    /// List of the tokens that were minted successfully (some may have been burned during hook
+    /// execution).
     pub token_ids: Vec<TokenID>,
-    /// (Optional) data returned from the receiver hook
+    /// (Optional) data returned from the receiver hook.
     pub recipient_data: RawBytes,
 }
 
-/// Intermediate data used by mint_return to construct the return data
+/// Intermediate data used by mint_return to construct the return data.
 #[derive(Clone, Debug)]
 pub struct MintIntermediate {
-    /// Receiving address used for querying balance
+    /// Receiving address used for querying balance.
     pub to: ActorID,
-    /// List of the newly minted tokens
+    /// List of the newly minted tokens.
     pub token_ids: Vec<TokenID>,
-    /// (Optional) data returned from the receiver hook
+    /// (Optional) data returned from the receiver hook.
     pub recipient_data: RawBytes,
 }
 
@@ -97,13 +104,14 @@ impl RecipientData for MintIntermediate {
     }
 }
 
-/// Intermediate data used by transfer_return to construct the return data
+/// Intermediate data used by [`NFT::transfer_return`][`super::NFT::transfer_return`] to construct
+/// the return data.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct TransferIntermediate {
     pub token_ids: Vec<TokenID>,
     pub from: ActorID,
     pub to: ActorID,
-    /// (Optional) data returned from the receiver hook
+    /// (Optional) data returned from the receiver hook.
     pub recipient_data: RawBytes,
 }
 
@@ -171,7 +179,7 @@ pub struct RevokeForAllParams {
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListTokensParams {
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning start of list
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub cursor: RawBytes,
     pub limit: u64,
 }
@@ -179,14 +187,14 @@ pub struct ListTokensParams {
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListTokensReturn {
     pub tokens: BitField,
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning no more items
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub next_cursor: Option<RawBytes>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListOwnedTokensParams {
     pub owner: Address,
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning start of list
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub cursor: RawBytes,
     pub limit: u64,
 }
@@ -194,14 +202,14 @@ pub struct ListOwnedTokensParams {
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListOwnedTokensReturn {
     pub tokens: TokenSet,
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning no more items
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub next_cursor: Option<RawBytes>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListTokenOperatorsParams {
     pub token_id: TokenID,
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning start of list
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub cursor: RawBytes,
     pub limit: u64,
 }
@@ -209,14 +217,14 @@ pub struct ListTokenOperatorsParams {
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListTokenOperatorsReturn {
     pub operators: ActorIDSet,
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning no more items
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub next_cursor: Option<RawBytes>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListOperatorTokensParams {
     pub operator: Address,
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning start of list
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub cursor: RawBytes,
     pub limit: u64,
 }
@@ -224,14 +232,14 @@ pub struct ListOperatorTokensParams {
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListOperatorTokensReturn {
     pub tokens: TokenSet,
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning no more items
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub next_cursor: Option<RawBytes>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListAccountOperatorsParams {
     pub owner: Address,
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning start of list
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub cursor: RawBytes,
     pub limit: u64,
 }
@@ -239,6 +247,6 @@ pub struct ListAccountOperatorsParams {
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
 pub struct ListAccountOperatorsReturn {
     pub operators: ActorIDSet,
-    /// Opaque serialisation of frc53_nft::state::Cursor, with empty cursor meaning no more items
+    /// Opaque serialisation of [`Cursor`], with empty cursor meaning start of list.
     pub next_cursor: Option<RawBytes>,
 }

--- a/frc53_nft/src/util.rs
+++ b/frc53_nft/src/util.rs
@@ -2,15 +2,15 @@ use fvm_ipld_bitfield::BitField;
 use fvm_shared::ActorID;
 
 pub trait OperatorSet {
-    /// Attempts to add the operator to the authorised list
+    /// Attempts to add the operator to the authorised list.
     ///
-    /// Returns true if the operator was added, false if it was already present
+    /// Returns true if the operator was added, false if it was already present.
     fn add_operator(&mut self, operator: ActorID);
 
-    /// Removes the operator from the authorised list
+    /// Removes the operator from the authorised list.
     fn remove_operator(&mut self, operator: &ActorID);
 
-    /// Checks if the operator is present in the list
+    /// Checks if the operator is present in the list.
     fn contains_actor(&self, operator: &ActorID) -> bool;
 }
 
@@ -28,14 +28,16 @@ impl OperatorSet for BitField {
     }
 }
 
-/// Maintains set-like invariants in-memory by maintaining sorted order of the underlying array
-/// Insertion and deletion are O(n) operations but we expect operator lists to be a relatively small size
-/// TODO: benchmark this against some other options such as
-/// - BTreeSet in memory, Vec serialized
-/// - BTreeSet in memory and serialization
-/// - HashSets...
-/// - Hamt<ActorID, ()>
-/// - Amt<ActorID>
+/// Maintains set-like invariants in-memory by maintaining sorted order of the underlying array.
+///
+/// Insertion and deletion are O(n) operations but we expect operator lists to be a relatively small
+/// size.
+// TODO: benchmark this against some other options such as
+// - BTreeSet in memory, Vec serialized
+// - BTreeSet in memory and serialization
+// - HashSets...
+// - Hamt<ActorID, ()>
+// - Amt<ActorID>
 impl OperatorSet for Vec<ActorID> {
     fn add_operator(&mut self, id: ActorID) {
         if let Err(pos) = self.binary_search(&id) {

--- a/frc53_nft/src/util.rs
+++ b/frc53_nft/src/util.rs
@@ -28,16 +28,17 @@ impl OperatorSet for BitField {
     }
 }
 
-/// Maintains set-like invariants in-memory by maintaining sorted order of the underlying array.
-///
-/// Insertion and deletion are O(n) operations but we expect operator lists to be a relatively small
-/// size.
 // TODO: benchmark this against some other options such as
 // - BTreeSet in memory, Vec serialized
 // - BTreeSet in memory and serialization
 // - HashSets...
 // - Hamt<ActorID, ()>
 // - Amt<ActorID>
+
+/// Maintains set-like invariants in-memory by maintaining sorted order of the underlying array.
+///
+/// Insertion and deletion are O(n) operations but we expect operator lists to be a relatively small
+/// size.
 impl OperatorSet for Vec<ActorID> {
     fn add_operator(&mut self, id: ActorID) {
         if let Err(pos) = self.binary_search(&id) {

--- a/fvm_actor_utils/src/actor.rs
+++ b/fvm_actor_utils/src/actor.rs
@@ -11,13 +11,13 @@ pub enum ActorError {
 
 type Result<T> = std::result::Result<T, ActorError>;
 
-/// Generic utils related to actors on the FVM
+/// Generic utils related to actors on the FVM.
 pub trait Actor {
-    /// Get the root cid of the actor's state
+    /// Get the root cid of the actor's state.
     fn root_cid(&self) -> Result<Cid>;
 }
 
-/// A helper handle for actors deployed on FVM
+/// A helper handle for actors deployed on FVM.
 pub struct FvmActor {}
 
 impl Actor for FvmActor {
@@ -26,7 +26,7 @@ impl Actor for FvmActor {
     }
 }
 
-/// A fake actor fixture that can be twiddled for testing
+/// A fake actor fixture that can be twiddled for testing.
 #[derive(Default, Clone, Debug)]
 pub struct FakeActor {
     pub root: Cid,

--- a/fvm_actor_utils/src/blockstore.rs
+++ b/fvm_actor_utils/src/blockstore.rs
@@ -9,8 +9,10 @@ use fvm_sdk::ipld;
 #[derive(Default, Debug, Copy, Clone)]
 pub struct Blockstore;
 
-/// Blockstore implementation is borrowed from https://github.com/filecoin-project/builtin-actors/blob/6df845dcdf9872beb6e871205eb34dcc8f7550b5/runtime/src/runtime/actor_blockstore.rs
-/// This impl will likely be made redundant if low-level SDKs export blockstore implementations
+/// Blockstore implementation is borrowed from [the builtin actors][source]. This impl will likely
+/// be made redundant if low-level SDKs export blockstore implementations.
+///
+/// [source]: https://github.com/filecoin-project/builtin-actors/blob/6df845dcdf9872beb6e871205eb34dcc8f7550b5/runtime/src/runtime/actor_blockstore.rs
 impl fvm_ipld_blockstore::Blockstore for Blockstore {
     fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
         // If this fails, the _CID_ is invalid. I.e., we have a bug.

--- a/fvm_actor_utils/src/messaging.rs
+++ b/fvm_actor_utils/src/messaging.rs
@@ -46,9 +46,9 @@ impl From<&MessagingError> for ExitCode {
     }
 }
 
-/// An abstraction used to send messages to other actors
+/// An abstraction used to send messages to other actors.
 pub trait Messaging {
-    /// Sends a message to an actor
+    /// Sends a message to an actor.
     fn send(
         &self,
         to: &Address,
@@ -59,7 +59,7 @@ pub trait Messaging {
 }
 
 /// This method number comes from taking the name as "Receive" and applying
-/// the transformation described in [FRC-0042](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md)
+/// the transformation described in [FRC-0042](https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0042.md).
 pub const RECEIVER_HOOK_METHOD_NUM: u64 = method_hash!("Receive");
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/fvm_actor_utils/src/shared_blockstore.rs
+++ b/fvm_actor_utils/src/shared_blockstore.rs
@@ -4,8 +4,10 @@ use anyhow::Result;
 use cid::Cid;
 use fvm_ipld_blockstore::MemoryBlockstore;
 
-/// A shared wrapper around MemoryBlockstore
-/// Clones of it will reference the same underlying MemoryBlockstore, allowing for more complex unit testing
+/// A shared wrapper around [`MemoryBlockstore`].
+///
+/// Clones of it will reference the same underlying [`MemoryBlockstore`], allowing for more complex
+/// unit testing.
 #[derive(Debug, Clone)]
 pub struct SharedMemoryBlockstore {
     store: Rc<MemoryBlockstore>,

--- a/fvm_actor_utils/src/syscalls/fake_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fake_syscalls.rs
@@ -17,27 +17,27 @@ pub struct TestMessage {
 
 #[derive(Clone, Default, Debug)]
 pub struct FakeSyscalls {
-    /// The root of the receiving actor
+    /// The root of the receiving actor.
     pub root: RefCell<Cid>,
-    /// The f0 ID of the receiving actor
+    /// The f0 ID of the receiving actor.
     pub actor_id: ActorID,
 
-    /// Actor ID to return as caller ID
+    /// Actor ID to return as caller ID.
     pub caller_id: RefCell<ActorID>,
 
-    /// A map of addresses that were instantiated in this runtime
+    /// A map of addresses that were instantiated in this runtime.
     pub addresses: RefCell<HashMap<Address, ActorID>>,
-    /// The next-to-allocate f0 address
+    /// The next-to-allocate f0 address.
     pub next_actor_id: RefCell<ActorID>,
 
-    /// The last message sent via this runtime
+    /// The last message sent via this runtime.
     pub last_message: RefCell<Option<TestMessage>>,
-    /// Flag to control message success
+    /// Flag to control message success.
     pub abort_next_send: RefCell<bool>,
 }
 
 impl FakeSyscalls {
-    /// Set the ActorID returned as caller
+    /// Set the ActorID returned as caller.
     pub fn set_caller_id(&self, new_id: ActorID) {
         self.caller_id.replace(new_id);
     }

--- a/fvm_actor_utils/src/syscalls/fvm_syscalls.rs
+++ b/fvm_actor_utils/src/syscalls/fvm_syscalls.rs
@@ -8,7 +8,7 @@ use fvm_shared::{address::Address, MethodNum, Response};
 use super::Syscalls;
 use crate::util::ActorRuntime;
 
-/// Runtime that delegates to fvm_sdk allowing actors to be deployed on-chain
+/// Runtime that delegates to [`fvm_sdk`] allowing actors to be deployed on-chain.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct FvmSyscalls {}
 

--- a/fvm_actor_utils/src/syscalls/mod.rs
+++ b/fvm_actor_utils/src/syscalls/mod.rs
@@ -8,14 +8,14 @@ use thiserror::Error;
 pub mod fake_syscalls;
 pub mod fvm_syscalls;
 
-/// Copied to avoid linking against `fvm_sdk` for non-WASM targets
+/// Copied to avoid linking against `fvm_sdk` for non-WASM targets.
 #[derive(Copy, Clone, Debug, Error)]
 #[error("actor does not exist in state-tree")]
 pub struct NoStateError;
 
 /// The Syscalls trait defines methods available to the actor from its execution environment.
 ///
-/// The methods available are a subset of the methods exported by `fvm_sdk`
+/// The methods available are a subset of the methods exported by `fvm_sdk`.
 pub trait Syscalls {
     /// Get the IPLD root CID. Fails if the actor doesn't have state (before the first call to
     /// `set_root` and after actor deletion).
@@ -29,13 +29,13 @@ pub trait Syscalls {
     /// - Fails if the actor has been deleted.
     fn set_root(&self, cid: &Cid) -> Result<(), NoStateError>;
 
-    /// Returns the ID address of the actor
+    /// Returns the ID address of the actor.
     fn receiver(&self) -> ActorID;
 
-    /// Returns the ID address of the calling actor
+    /// Returns the ID address of the calling actor.
     fn caller(&self) -> ActorID;
 
-    /// Sends a message to an actor
+    /// Sends a message to an actor.
     fn send(
         &self,
         to: &Address,
@@ -47,6 +47,6 @@ pub trait Syscalls {
     /// Resolves the ID address of an actor.
     ///
     /// Returns None if the address cannot be resolved. Successfully resolving an address doesn't
-    /// necessarily mean the actor exists (e.g., if the addresss was already an actor ID).
+    /// necessarily mean the actor exists (e.g., if the address was already an actor ID).
     fn resolve_address(&self, addr: &Address) -> Option<ActorID>;
 }

--- a/fvm_dispatch_tools/src/main.rs
+++ b/fvm_dispatch_tools/src/main.rs
@@ -11,7 +11,7 @@ const LONG_ABOUT: &str =
     "Pass a single method name as a command line argument or a list of method names, separated by \
 new-lines to stdin. The output is a list of hashes, one per method name.";
 
-/// Takes a method name and converts it to an FRC-0042 compliant method number
+/// Takes a method name and converts it to an FRC-0042 compliant method number.
 ///
 /// Can be used by actor authors to precompute the method number for a given exported method to
 /// avoid runtime hasing during dispatch.
@@ -22,7 +22,7 @@ new-lines to stdin. The output is a list of hashes, one per method name.";
     long_about = Some(LONG_ABOUT)
 )]
 struct Args {
-    /// Method name to hash
+    /// Method name to hash.
     method_name: Option<String>,
 }
 

--- a/testing/integration/tests/common/frc46_token_helpers.rs
+++ b/testing/integration/tests/common/frc46_token_helpers.rs
@@ -18,10 +18,11 @@ pub struct MintParams {
     pub operator_data: RawBytes,
 }
 
-/// Helper routines to simplify common token operations
+/// Helper routines to simplify common token operations.
 pub trait TokenHelper {
-    /// Get balance from token actor for a given address
-    /// This is a very common thing to check during tests
+    /// Get balance from token actor for a given address.
+    ///
+    /// This is a very common thing to check during tests.
     fn token_balance(
         &mut self,
         operator: Address,
@@ -29,7 +30,7 @@ pub trait TokenHelper {
         target: Address,
     ) -> TokenAmount;
 
-    /// Mint tokens from token_actor to target address
+    /// Mint tokens from token_actor to target address.
     fn mint_tokens(
         &mut self,
         operator: Address,
@@ -39,7 +40,7 @@ pub trait TokenHelper {
         operator_data: RawBytes,
     ) -> ApplyRet;
 
-    /// Mint tokens from token_actor to target address and assert a successful result
+    /// Mint tokens from token_actor to target address and assert a successful result.
     fn mint_tokens_ok(
         &mut self,
         operator: Address,
@@ -49,7 +50,7 @@ pub trait TokenHelper {
         operator_data: RawBytes,
     ) -> ApplyRet;
 
-    /// Check token balance, asserting that balance matches the provided amount
+    /// Check token balance, asserting that balance matches the provided amount.
     fn assert_token_balance(
         &mut self,
         operator: Address,
@@ -58,7 +59,7 @@ pub trait TokenHelper {
         amount: TokenAmount,
     );
 
-    /// Check token balance, asserting a zero balance
+    /// Check token balance, asserting a zero balance.
     fn assert_token_balance_zero(
         &mut self,
         operator: Address,
@@ -66,10 +67,10 @@ pub trait TokenHelper {
         target: Address,
     );
 
-    /// Get total supply of tokens
+    /// Get total supply of tokens.
     fn total_supply(&mut self, operator: Address, token_actor: Address) -> TokenAmount;
 
-    /// Check total supply, asserting that it matches the given amount
+    /// Check total supply, asserting that it matches the given amount.
     fn assert_total_supply(
         &mut self,
         operator: Address,

--- a/testing/integration/tests/common/frc53_nft_helpers.rs
+++ b/testing/integration/tests/common/frc53_nft_helpers.rs
@@ -20,11 +20,12 @@ pub struct MintParams {
 }
 
 pub trait NFTHelper {
-    /// Get balance from token actor for a given address
-    /// This is a very common thing to check during tests
+    /// Get balance from token actor for a given address.
+    ///
+    /// This is a very common thing to check during tests.
     fn nft_balance(&mut self, operator: Address, token_actor: Address, target: Address) -> u64;
 
-    /// Mint tokens from token_actor to target address
+    /// Mint tokens from token_actor to target address.
     fn mint_nfts(
         &mut self,
         operator: Address,
@@ -34,7 +35,7 @@ pub trait NFTHelper {
         operator_data: RawBytes,
     ) -> ApplyRet;
 
-    /// Mint tokens from token_actor to target address and assert a successful result
+    /// Mint tokens from token_actor to target address and assert a successful result.
     fn mint_nfts_ok(
         &mut self,
         operator: Address,
@@ -44,7 +45,7 @@ pub trait NFTHelper {
         operator_data: RawBytes,
     ) -> ApplyRet;
 
-    /// Check token balance, asserting that balance matches the provided amount
+    /// Check token balance, asserting that balance matches the provided amount.
     fn assert_nft_balance(
         &mut self,
         operator: Address,
@@ -53,16 +54,16 @@ pub trait NFTHelper {
         amount: u64,
     );
 
-    /// Check token balance, asserting a zero balance
+    /// Check token balance, asserting a zero balance.
     fn assert_nft_balance_zero(&mut self, operator: Address, token_actor: Address, target: Address);
 
-    /// Check the total supply, asserting that it matches the provided amount
+    /// Check the total supply, asserting that it matches the provided amount.
     fn assert_nft_total_supply(&mut self, operator: Address, token_actor: Address, amount: u64);
 
-    /// Check the total supply, asserting that it is zero
+    /// Check the total supply, asserting that it is zero.
     fn assert_nft_total_supply_zero(&mut self, operator: Address, token_actor: Address);
 
-    /// Check the tokens owner, asserting that it is owned by the specified ActorID
+    /// Check the tokens owner, asserting that it is owned by the specified ActorID.
     fn assert_nft_owner(
         &mut self,
         operator: Address,
@@ -71,7 +72,7 @@ pub trait NFTHelper {
         owner: ActorID,
     );
 
-    /// Check the tokens metadata, asserting that it matches the provided metadata
+    /// Check the tokens metadata, asserting that it matches the provided metadata.
     fn assert_nft_metadata(
         &mut self,
         operator: Address,

--- a/testing/integration/tests/common/mod.rs
+++ b/testing/integration/tests/common/mod.rs
@@ -17,9 +17,9 @@ use serde::Serialize;
 pub mod frc46_token_helpers;
 pub mod frc53_nft_helpers;
 
-/// Helper routines to simplify common operations with a Tester
+/// Helper routines to simplify common operations with a [`Tester`].
 pub trait TestHelpers {
-    /// Call a method on an actor
+    /// Call a method on an actor.
     fn call_method(
         &mut self,
         from: Address,
@@ -28,7 +28,7 @@ pub trait TestHelpers {
         params: Option<RawBytes>,
     ) -> ApplyRet;
 
-    /// Call a method on an actor and assert a successful result
+    /// Call a method on an actor and assert a successful result.
     fn call_method_ok(
         &mut self,
         from: Address,
@@ -37,8 +37,9 @@ pub trait TestHelpers {
         params: Option<RawBytes>,
     ) -> ApplyRet;
 
-    /// Install an actor with initial state and ID
-    /// Returns the actor's address
+    /// Install an actor with initial state and ID.
+    ///
+    /// Returns the actor's address.
     fn install_actor_with_state<S: Serialize>(
         &mut self,
         code: &[u8],
@@ -46,8 +47,9 @@ pub trait TestHelpers {
         state: S,
     ) -> Address;
 
-    /// Install an actor with no initial state
-    /// Takes ID and returns the new actor's address
+    /// Install an actor with no initial state.
+    ///
+    /// Takes ID and returns the new actor's [`Address`].
     fn install_actor_stateless(&mut self, code: &[u8], actor_id: u64) -> Address;
 }
 
@@ -57,8 +59,10 @@ pub fn load_actor_wasm(path: &str) -> Vec<u8> {
     std::fs::read(wasm_path).expect("unable to read actor file")
 }
 
-/// Construct a Tester with the provided blockstore
-/// mainly cuts down on noise with importing the built-in actor bundle and network/state tree versions
+/// Construct a [`Tester`] with the provided [`Blockstore`].
+///
+/// This mainly cuts down on noise with importing the built-in actor bundle and network/state tree
+/// versions.
 pub fn construct_tester<BS: Blockstore + Clone, E: Externs>(blockstore: &BS) -> Tester<BS, E> {
     let bundle_root = bundle::import_bundle(&blockstore, actors_v12::BUNDLE_CAR).unwrap();
 

--- a/testing/integration/tests/frc46_single_actor_tests.rs
+++ b/testing/integration/tests/frc46_single_actor_tests.rs
@@ -16,9 +16,12 @@ use serde::{Deserialize, Serialize};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use token_impl::ConstructorParams;
 
-/// This covers several simpler tests, which all involve a single receiving actor
-/// They're combined because these integration tests take a long time to build and run
+/// This covers several simpler tests, which all involve a single receiving actor.
+///
+/// They're combined because these integration tests take a long time to build and run.
+///
 /// Test cases covered:
+///
 /// - mint to test actor who rejects in receiver hook
 /// - mint to self (token actor - should be rejected)
 /// - mint to test actor who burns tokens upon receipt (calling Burn from within the hook)

--- a/testing/integration/tests/frc53_multi_actor_tests.rs
+++ b/testing/integration/tests/frc53_multi_actor_tests.rs
@@ -441,7 +441,8 @@ fn frc53_multi_actor_tests() {
     }
 }
 
-/// These types have been duplicated from frc53_test_actor as we can't import into rust from a cdylib
+/// These types have been duplicated from `frc53_test_actor` as we can't import into rust from a
+/// cdylib.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum TestAction {
     Accept,

--- a/testing/test_actors/actors/basic_nft_actor/src/lib.rs
+++ b/testing/test_actors/actors/basic_nft_actor/src/lib.rs
@@ -198,7 +198,7 @@ pub fn constructor() {
 // Note that the below MintParams needs to be manually synced with
 // testing/fil_token_integration/tests/frc53_nfts.rs::MintParams
 
-/// Minting tokens goes directly to the caller for now
+/// Minting tokens goes directly to the caller for now.
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, Clone)]
 pub struct MintParams {
     pub initial_owner: Address,
@@ -206,7 +206,7 @@ pub struct MintParams {
     pub operator_data: RawBytes,
 }
 
-/// Grab the incoming parameters and convert from RawBytes to deserialized struct
+/// Grab the incoming parameters and convert from RawBytes to deserialized struct.
 pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
     let params = sdk::message::params_raw(params).unwrap().unwrap();
     let params = RawBytes::new(params.data);

--- a/testing/test_actors/actors/basic_receiving_actor/src/lib.rs
+++ b/testing/test_actors/actors/basic_receiving_actor/src/lib.rs
@@ -7,7 +7,7 @@ use fvm_sdk as sdk;
 use fvm_shared::error::ExitCode;
 use sdk::NO_DATA_BLOCK_ID;
 
-/// Grab the incoming parameters and convert from RawBytes to deserialized struct
+/// Grab the incoming parameters and convert from RawBytes to deserialized struct.
 pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
     let params = sdk::message::params_raw(params).unwrap().unwrap();
     let params = RawBytes::new(params.data);

--- a/testing/test_actors/actors/basic_token_actor/src/lib.rs
+++ b/testing/test_actors/actors/basic_token_actor/src/lib.rs
@@ -24,13 +24,13 @@ use thiserror::Error;
 use util::{caller_address, deserialize_params, RuntimeError};
 
 struct BasicToken<'state> {
-    /// Default token helper impl
+    /// Default token helper impl.
     util: Token<'state, FvmSyscalls, Blockstore>,
 }
 
-/// Implementation of the token API in a FVM actor
+/// Implementation of the token API in a FVM actor.
 ///
-/// Here the Ipld parameter structs are marshalled and passed to the underlying library functions
+/// Here the Ipld parameter structs are marshalled and passed to the underlying library functions.
 impl FRC46Token for BasicToken<'_> {
     type TokenError = RuntimeError;
     fn name(&self) -> String {

--- a/testing/test_actors/actors/basic_token_actor/src/util.rs
+++ b/testing/test_actors/actors/basic_token_actor/src/util.rs
@@ -5,13 +5,13 @@ use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use thiserror::Error;
 
-/// Errors that can occur during the execution of this actor
+/// Errors that can occur during the execution of this actor.
 #[derive(Error, Debug)]
 pub enum RuntimeError {
-    /// Error from the underlying token library
+    /// Error from the underlying token library.
     #[error("error in token: {0}")]
     Token(#[from] TokenError),
-    /// Error from the underlying universal receiver hook library
+    /// Error from the underlying universal receiver hook library.
     #[error("error calling receiver hook: {0}")]
     Receiver(#[from] ReceiverHookError),
 }
@@ -21,7 +21,7 @@ pub fn caller_address() -> Address {
     Address::new_id(caller)
 }
 
-/// Grab the incoming parameters and convert from RawBytes to deserialized struct
+/// Grab the incoming parameters and convert from [`RawBytes`] to deserialized struct.
 pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
     let params = sdk::message::params_raw(params).unwrap().unwrap();
     let params = RawBytes::new(params.data);

--- a/testing/test_actors/actors/basic_transfer_actor/src/lib.rs
+++ b/testing/test_actors/actors/basic_transfer_actor/src/lib.rs
@@ -12,7 +12,7 @@ use fvm_shared::sys::SendFlags;
 use fvm_shared::{address::Address, bigint::Zero, econ::TokenAmount, error::ExitCode};
 use sdk::NO_DATA_BLOCK_ID;
 
-/// Grab the incoming parameters and convert from RawBytes to deserialized struct
+/// Grab the incoming parameters and convert from [`RawBytes`] to the deserialized struct.
 pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
     let params = sdk::message::params_raw(params).unwrap().unwrap();
     let params = RawBytes::new(params.data);
@@ -38,17 +38,18 @@ impl TransferActorState {
     }
 }
 
-/// Implements a simple actor that can hold and transfer tokens
+/// Implements a simple actor that can hold and transfer tokens.
 ///
-/// First operator to send it tokens will be saved and tokens from other operators will be rejected
+/// First operator to send it tokens will be saved and tokens from other operators will be rejected.
 ///
-/// Address of the token actor is also saved as this identifies the token type
+/// Address of the token actor is also saved as this identifies the token type.
 ///
-/// After receiving some tokens, it does nothing until the Forward method is called by the initial operator
-/// When Forward method is invoked, it will transfer the entire balance it holds to a given address
+/// After receiving some tokens, it does nothing until the Forward method is called by the initial
+/// operator. When the `Forward` method is invoked, it will transfer the entire balance it holds to
+/// a given address.
 ///
 /// Forward requires the same operator to initiate transfer and will abort if the operator address doesn't match,
-/// or if the receiver hook rejects the transfer
+/// or if the receiver hook rejects the transfer.
 #[no_mangle]
 fn invoke(input: u32) -> u32 {
     std::panic::set_hook(Box::new(|info| {

--- a/testing/test_actors/actors/frc53_test_actor/src/lib.rs
+++ b/testing/test_actors/actors/frc53_test_actor/src/lib.rs
@@ -17,7 +17,7 @@ use fvm_shared::{address::Address, bigint::Zero, econ::TokenAmount, error::ExitC
 use sdk::NO_DATA_BLOCK_ID;
 use serde::{Deserialize, Serialize};
 
-/// Grab the incoming parameters and convert from RawBytes to deserialized struct
+/// Grab the incoming parameters and convert from [`RawBytes`] to deserialized struct.
 pub fn deserialize_params<O: DeserializeOwned>(params: u32) -> O {
     let params = sdk::message::params_raw(params).unwrap().unwrap();
     let params = RawBytes::new(params.data);
@@ -32,42 +32,45 @@ where
     sdk::ipld::put_block(DAG_CBOR, &bytes).unwrap()
 }
 
-/// Action to take in receiver hook or Action method
-/// This gets serialized and sent along as operator_data
+/// Action to take in receiver hook or Action method.
+///
+/// This gets serialized and sent along as operator_data.
 #[derive(Serialize, Deserialize, Debug)]
 pub enum TestAction {
-    /// Accept the tokens
+    /// Accept the tokens.
     Accept,
-    /// Reject the tokens (hook aborts)
+    /// Reject the tokens (hook aborts).
     Reject,
-    /// Transfer to another address (with operator_data that can provide further instructions)
+    /// Transfer to another address (with operator_data that can provide further instructions).
     Transfer(Address, Vec<TokenID>, RawBytes),
-    /// Burn incoming tokens
+    /// Burn incoming tokens.
     Burn(Vec<TokenID>),
 }
 
-/// Params for Action method call
-/// This gives us a way to supply the token address, since we won't get it as a sender like we do for hook calls
+/// Params for Action method call.
+///
+/// This gives us a way to supply the token address, since we won't get it as a sender like we do
+/// for hook calls.
 #[derive(Serialize_tuple, Deserialize_tuple, Debug)]
 pub struct ActionParams {
-    /// Address of the token actor
+    /// Address of the token actor.
     pub token_address: Address,
     /// Action to take with our token balance. Only Transfer and Burn actions apply here.
     pub action: TestAction,
 }
 
-/// Helper for nesting calls to create action sequences
-/// eg. transfer and then the receiver hook rejects:
-/// action(TestAction::Transfer(
-///         some_address,
-///         action(TestAction::Reject),
-///     ),
-/// )
+/// Helper for nesting calls to create action sequences.
+///
+/// E.g., transfer and then the receiver hook rejects:
+///
+/// ```ignore
+/// action(TestAction::Transfer(some_address, action(TestAction::Reject)));
+/// ```
 pub fn action(action: TestAction) -> RawBytes {
     RawBytes::serialize(action).unwrap()
 }
 
-/// Execute the Transfer action
+/// Execute the Transfer action.
 fn transfer(token: Address, to: Address, token_ids: Vec<TokenID>, operator_data: RawBytes) -> u32 {
     let transfer_params = TransferParams { to, token_ids, operator_data };
     let ret = sdk::send::send(
@@ -88,7 +91,7 @@ fn transfer(token: Address, to: Address, token_ids: Vec<TokenID>, operator_data:
     })
 }
 
-/// Execute the Burn action
+/// Execute the Burn action.
 fn burn(token: Address, token_ids: Vec<TokenID>) -> u32 {
     let ret = sdk::send::send(
         &token,


### PR DESCRIPTION
Clippy was complaining about list indentation and paragraph separation, so I fixed that and a few other issues (links to types, etc.).

I may have gone a little ham but... I couldn't stop once I started.