### PR TITLE
chore: release major versions of all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ anyhow = { version = "1.0.56" }
 multihash-codetable = { version = "0.1.4" }
 
 # internal deps of published packages
-frc42_dispatch = { version = "7.0.0", path = "./frc42_dispatch", default-features = false }
-fvm_actor_utils = { version = "11.0.0", path = "./fvm_actor_utils" }
+frc42_dispatch = { version = "8.0.0", path = "./frc42_dispatch", default-features = false }
+fvm_actor_utils = { version = "12.0.0", path = "./fvm_actor_utils" }
 
 # only consumed by non-published packages
 frc53_nft = { path = "./frc53_nft" }

--- a/frc42_dispatch/Cargo.toml
+++ b/frc42_dispatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc42_dispatch"
 description = "Filecoin FRC-0042 calling convention/dispatch support library"
-version = "7.0.0"
+version = "8.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "dispatch", "frc-0042"]
 repository = "https://github.com/helix-onchain/filecoin/"
@@ -12,8 +12,8 @@ edition = "2021"
 fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true, optional = true }
 fvm_shared = { workspace = true }
-frc42_hasher = { version = "5.0.0", path = "hasher" }
-frc42_macros = { version = "5.0.0", path = "macros" }
+frc42_hasher = { version = "6.0.0", path = "hasher" }
+frc42_macros = { version = "6.0.0", path = "macros" }
 thiserror = { version = "1.0.31" }
 
 [features]

--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_hasher"
-version = "5.0.0"
+version = "6.0.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention method hashing"
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc42_dispatch/macros/Cargo.toml
+++ b/frc42_dispatch/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frc42_macros"
-version = "5.0.0"
+version = "6.0.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention procedural macros"
 repository = "https://github.com/helix-onchain/filecoin/"
@@ -11,7 +11,7 @@ proc-macro = true
 
 [dependencies]
 blake2b_simd = { version = "1.0.0" }
-frc42_hasher = { version = "5.0.0", path = "../hasher", default-features = false }
+frc42_hasher = { version = "6.0.0", path = "../hasher", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/frc42_dispatch/macros/example/Cargo.toml
+++ b/frc42_dispatch/macros/example/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-frc42_macros = { version = "5.0.0", path = ".." }
+frc42_macros = { version = "6.0.0", path = ".." }

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc46_token"
 description = "Filecoin FRC-0046 fungible token reference implementation"
-version = "11.0.0"
+version = "12.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "frc-0046"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc53_nft/Cargo.toml
+++ b/frc53_nft/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "frc53_nft"
 description = "Filecoin FRC-0053 non-fungible token reference implementation"
-version = "5.0.0"
+version = "6.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "nft", "frc-0053"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/fvm_actor_utils/Cargo.toml
+++ b/fvm_actor_utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fvm_actor_utils"
 description = "Utils for authoring native actors for the Filecoin Virtual Machine"
-version = "11.0.0"
+version = "12.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/fvm_dispatch_tools/Cargo.toml
+++ b/fvm_dispatch_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fvm_dispatch_tools"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Release for FVM v4.5 and the updates to cid & multihash.

- frc42_dispatch@v8.0.0
- frc42_macros@v6.0.0
- frc42_hasher@v6.0.0
- frc46_token@v12.0.0
- frc53_nft@v6.0.0
- fvm_actor_utils@v12.0.0
- fvm_dispatch_tools@v0.4.0