### PR TITLE
chore: remove default features from multihash-codetable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = { version = "1.0.31" }
 integer-encoding = { version = "4.0.0" }
 num-traits = { version = "0.2.15" }
 anyhow = { version = "1.0.56" }
-multihash-codetable = { version = "0.1.4" }
+multihash-codetable = { version = "0.1.4", default-features = false }
 
 # internal deps of published packages
 frc42_dispatch = { version = "8.0.0", path = "./frc42_dispatch", default-features = false }

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -17,7 +17,7 @@ fvm_ipld_hamt = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
-multihash-codetable = { workspace = true }
+multihash-codetable = { workspace = true, features = ["blake2b"] }
 num-traits = { workspace = true }
 serde = { workspace = true }
 serde_tuple = { workspace = true }

--- a/frc53_nft/Cargo.toml
+++ b/frc53_nft/Cargo.toml
@@ -21,7 +21,7 @@ fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 integer-encoding = { workspace = true }
-multihash-codetable = { workspace = true }
+multihash-codetable = { workspace = true, features = ["blake2b"] }
 num-traits = { workspace = true }
 serde = { workspace = true }
 serde_tuple = { workspace = true }

--- a/testing/test_actors/actors/basic_transfer_actor/Cargo.toml
+++ b/testing/test_actors/actors/basic_transfer_actor/Cargo.toml
@@ -14,7 +14,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
-multihash-codetable = { workspace = true }
+multihash-codetable = { workspace = true, features = ["blake2b"] }
 serde = { workspace = true }
 serde_tuple = { workspace = true }
 

--- a/testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml
+++ b/testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml
@@ -13,7 +13,7 @@ fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
-multihash-codetable = { workspace = true }
+multihash-codetable = { workspace = true, features = ["blake2b"] }
 serde = { workspace = true }
 serde_tuple = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
This doesn't (yet) appear to make a difference but, once we release & update the builtin actors again, we may be able to drop a few dependencies from our tree? Regardless, it can't hurt.