### PR TITLE
chore: switch back to builtin-actors master

### DIFF
--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -23,6 +23,6 @@ serde = { workspace = true }
 serde_tuple = { workspace = true }
 
 [dev-dependencies]
-actors = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "steb/update-multihash" }
+actors = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
 helix_test_actors = { path = "../test_actors" }
 token_impl = { path = "../test_actors/actors/frc46_factory_token/token_impl" }


### PR DESCRIPTION
Now that the breaking cid/multihash changes have been merged, we can switch back.