### PR TITLE
chore: update fvm to 4.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ clap = { version = "4.3.21", features = ["derive"] }
 cid = { version = "0.11.1", default-features = false, features = [
     "serde",
 ] }
-fvm = { version = "~4.5", default-features = false }
-fvm_integration_tests = "~4.5"
+fvm = { version = "~4.6", default-features = false }
+fvm_integration_tests = "~4.6"
 fvm_ipld_amt = "0.7.3"
-fvm_ipld_bitfield = "0.7.0"
-fvm_ipld_blockstore = "0.3.0"
-fvm_ipld_encoding = "0.5.0"
-fvm_ipld_hamt = "0.10.2"
-fvm_sdk = "~4.5"
-fvm_shared = "~4.5"
+fvm_ipld_bitfield = "0.7.1"
+fvm_ipld_blockstore = "0.3.1"
+fvm_ipld_encoding = "0.5.2"
+fvm_ipld_hamt = "0.10.3"
+fvm_sdk = "~4.6"
+fvm_shared = "~4.6"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }


### PR DESCRIPTION
This has a minor breaking change to the shared crate, but it still warranted a minor release.