### PR TITLE
test: fetch actors bundle from github instead of using cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Cargo.lock
 # Code coverage instrumentation
 coverage/
 *.profraw
+
+testing/bundles/

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Dual-licensed: [MIT](./LICENSE-MIT),
 
 ## Testing
 
+The tests require downloading a builtin-actors bundle. Either run the tests with `make test` or run `make test-deps` before running tests manually with cargo.
+
+You can change the actors version by changing `ACTORS_VERSION` in the `Makefile`. If you want to test with a custom bundle entirely, replace the `testing/bundles/builtin-actors.car` symlink with the custom bundle. Note, however, that running `make test` will revert that change, so you'll want to test with `cargo test` manually.
+
 For local coverage testing, please install the `grcov` crate.
 
 <sub>Copyright Protocol Labs, Inc, 2022</sub>

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -24,5 +24,4 @@ serde_tuple = { workspace = true }
 
 [dev-dependencies]
 helix_test_actors = { path = "../test_actors" }
-reqwest = "0.12.15"
 token_impl = { path = "../test_actors/actors/frc46_factory_token/token_impl" }

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -23,6 +23,6 @@ serde = { workspace = true }
 serde_tuple = { workspace = true }
 
 [dev-dependencies]
-actors = { package = "fil_builtin_actors_bundle", git = "https://github.com/filecoin-project/builtin-actors", branch = "master" }
 helix_test_actors = { path = "../test_actors" }
+reqwest = "0.12.15"
 token_impl = { path = "../test_actors/actors/frc46_factory_token/token_impl" }

--- a/testing/integration/tests/common/mod.rs
+++ b/testing/integration/tests/common/mod.rs
@@ -18,6 +18,8 @@ use serde::Serialize;
 pub mod frc46_token_helpers;
 pub mod frc53_nft_helpers;
 
+static BUNDLE_CAR: &'static [u8] = include_bytes!("../../../bundles/builtin-actors.car");
+
 /// Helper routines to simplify common operations with a [`Tester`].
 pub trait TestHelpers {
     /// Call a method on an actor.
@@ -65,7 +67,7 @@ pub fn load_actor_wasm(path: &str) -> Vec<u8> {
 /// This mainly cuts down on noise with importing the built-in actor bundle and network/state tree
 /// versions.
 pub fn construct_tester<BS: Blockstore + Clone, E: Externs>(blockstore: &BS) -> Tester<BS, E> {
-    let bundle_root = bundle::import_bundle(&blockstore, actors::BUNDLE_CAR).unwrap();
+    let bundle_root = bundle::import_bundle(&blockstore, BUNDLE_CAR).unwrap();
 
     Tester::new(NetworkVersion::V21, StateTreeVersion::V5, bundle_root, blockstore.clone()).unwrap()
 }

--- a/testing/integration/tests/frc46_tokens.rs
+++ b/testing/integration/tests/frc46_tokens.rs
@@ -2,20 +2,20 @@ use cid::Cid;
 use frc42_dispatch::method_hash;
 use frc46_token::token::{state::TokenState, types::MintReturn};
 use fvm::executor::{ApplyKind, Executor};
-use fvm_integration_tests::bundle;
 use fvm_integration_tests::dummy::DummyExterns;
-use fvm_integration_tests::tester::{Account, Tester};
+use fvm_integration_tests::tester::Account;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
 use fvm_shared::econ::TokenAmount;
 use fvm_shared::message::Message;
-use fvm_shared::state::StateTreeVersion;
-use fvm_shared::version::NetworkVersion;
 use helix_test_actors::BASIC_RECEIVING_ACTOR_BINARY;
 use helix_test_actors::BASIC_TOKEN_ACTOR_BINARY;
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+mod common;
+use common::construct_tester;
 
 // Duplicated type from basic_token_actor
 #[derive(Serialize_tuple, Deserialize_tuple, Clone, Debug)]
@@ -28,10 +28,7 @@ pub struct MintParams {
 #[test]
 fn it_mints_tokens() {
     let blockstore = MemoryBlockstore::default();
-    let bundle_root = bundle::import_bundle(&blockstore, actors::BUNDLE_CAR).unwrap();
-    let mut tester =
-        Tester::new(NetworkVersion::V21, StateTreeVersion::V5, bundle_root, blockstore.clone())
-            .unwrap();
+    let mut tester = construct_tester(&blockstore);
 
     let minter: [Account; 1] = tester.create_accounts().unwrap();
 


### PR DESCRIPTION
Primarily, this removes an annoying circular dependency between these utilities and the actors. Additionally, this makes it very clear that the actors we're building won't use the code in this repo. Unlike normal rust builds, actor bundle builds don't automatically patch workspaces.

I've configured it to fetch v15 and we'll have to update that as we go. If you want to test with newer actors, you'll need to build a bundle yourself and drop it in `testing/bundles/builtin-actors.car`.

Part of https://github.com/filecoin-project/builtin-actors/issues/1664