### PR TITLE
feat: switch away from the direct serde_tuple import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ fvm_ipld_hamt = "0.10.4"
 fvm_sdk = "~4.7"
 fvm_shared = "~4.7"
 serde = { version = "1.0.136", features = ["derive"] }
-serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }
 integer-encoding = { version = "4.0.0" }
 num-traits = { version = "0.2.15" }

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -20,6 +20,5 @@ fvm_shared = { workspace = true }
 multihash-codetable = { workspace = true, features = ["blake2b"] }
 num-traits = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 thiserror = { workspace = true }
 integer-encoding = { workspace = true }

--- a/frc46_token/src/receiver.rs
+++ b/frc46_token/src/receiver.rs
@@ -1,8 +1,8 @@
 use frc42_dispatch::method_hash;
 use fvm_actor_utils::receiver::{ReceiverHook, ReceiverHookError, ReceiverType, RecipientData};
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, ActorID};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 pub const FRC46_TOKEN_TYPE: ReceiverType = method_hash!("FRC46") as u32;
 

--- a/frc46_token/src/token/types.rs
+++ b/frc46_token/src/token/types.rs
@@ -1,5 +1,5 @@
 use fvm_actor_utils::receiver::RecipientData;
-use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;

--- a/frc53_nft/Cargo.toml
+++ b/frc53_nft/Cargo.toml
@@ -24,5 +24,4 @@ integer-encoding = { workspace = true }
 multihash-codetable = { workspace = true, features = ["blake2b"] }
 num-traits = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 thiserror = { workspace = true }

--- a/frc53_nft/src/receiver.rs
+++ b/frc53_nft/src/receiver.rs
@@ -1,8 +1,8 @@
 use frc42_dispatch::method_hash;
 use fvm_actor_utils::receiver::{ReceiverHook, ReceiverHookError, ReceiverType, RecipientData};
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, ActorID};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::types::TokenID;
 

--- a/frc53_nft/src/types.rs
+++ b/frc53_nft/src/types.rs
@@ -2,7 +2,7 @@
 use cid::Cid;
 use fvm_actor_utils::receiver::RecipientData;
 use fvm_ipld_bitfield::BitField;
-use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::ActorID;

--- a/fvm_actor_utils/Cargo.toml
+++ b/fvm_actor_utils/Cargo.toml
@@ -19,5 +19,4 @@ fvm_sdk = { workspace = true }
 multihash-codetable = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 thiserror = { workspace = true }

--- a/fvm_actor_utils/src/receiver/mod.rs
+++ b/fvm_actor_utils/src/receiver/mod.rs
@@ -1,7 +1,7 @@
 use std::mem;
 
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode};
 use num_traits::Zero;

--- a/testing/integration/Cargo.toml
+++ b/testing/integration/Cargo.toml
@@ -20,7 +20,6 @@ fvm_ipld_bitfield = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 
 [dev-dependencies]
 helix_test_actors = { path = "../test_actors" }

--- a/testing/integration/tests/common/frc46_token_helpers.rs
+++ b/testing/integration/tests/common/frc46_token_helpers.rs
@@ -2,9 +2,9 @@ use frc42_dispatch::method_hash;
 use fvm::{executor::ApplyRet, externs::Externs};
 use fvm_integration_tests::tester::Tester;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, bigint::Zero, econ::TokenAmount};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::TestHelpers;
 

--- a/testing/integration/tests/common/frc53_nft_helpers.rs
+++ b/testing/integration/tests/common/frc53_nft_helpers.rs
@@ -3,9 +3,9 @@ use frc53_nft::types::TokenID;
 use fvm::{executor::ApplyRet, externs::Externs};
 use fvm_integration_tests::tester::Tester;
 use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::{address::Address, ActorID};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use super::TestHelpers;
 

--- a/testing/integration/tests/frc46_multi_actor_tests.rs
+++ b/testing/integration/tests/frc46_multi_actor_tests.rs
@@ -10,9 +10,9 @@ use fvm_shared::{
 mod common;
 use common::frc46_token_helpers::TokenHelper;
 use common::{construct_tester, TestHelpers};
+use fvm_ipld_encoding::tuple::*;
 use helix_test_actors::{FRC46_FACTORY_TOKEN_ACTOR_BINARY, FRC46_TEST_ACTOR_BINARY};
 use serde::{Deserialize, Serialize};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use token_impl::ConstructorParams;
 
 #[test]

--- a/testing/integration/tests/frc46_single_actor_tests.rs
+++ b/testing/integration/tests/frc46_single_actor_tests.rs
@@ -11,9 +11,9 @@ use fvm_shared::{econ::TokenAmount, receipt::Receipt};
 mod common;
 use common::frc46_token_helpers::TokenHelper;
 use common::{construct_tester, TestHelpers};
+use fvm_ipld_encoding::tuple::*;
 use helix_test_actors::{FRC46_FACTORY_TOKEN_ACTOR_BINARY, FRC46_TEST_ACTOR_BINARY};
 use serde::{Deserialize, Serialize};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 use token_impl::ConstructorParams;
 
 /// This covers several simpler tests, which all involve a single receiving actor.

--- a/testing/integration/tests/frc46_tokens.rs
+++ b/testing/integration/tests/frc46_tokens.rs
@@ -5,6 +5,7 @@ use fvm::executor::{ApplyKind, Executor};
 use fvm_integration_tests::dummy::DummyExterns;
 use fvm_integration_tests::tester::Account;
 use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::RawBytes;
 use fvm_shared::address::Address;
 use fvm_shared::bigint::Zero;
@@ -12,7 +13,6 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::message::Message;
 use helix_test_actors::BASIC_RECEIVING_ACTOR_BINARY;
 use helix_test_actors::BASIC_TOKEN_ACTOR_BINARY;
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 mod common;
 use common::construct_tester;

--- a/testing/integration/tests/frc53_multi_actor_tests.rs
+++ b/testing/integration/tests/frc53_multi_actor_tests.rs
@@ -10,9 +10,9 @@ use fvm_shared::{address::Address, receipt::Receipt};
 mod common;
 use common::frc53_nft_helpers::{MintParams, NFTHelper};
 use common::{construct_tester, TestHelpers};
+use fvm_ipld_encoding::tuple::*;
 use helix_test_actors::{BASIC_NFT_ACTOR_BINARY, FRC53_TEST_ACTOR_BINARY};
 use serde::{Deserialize, Serialize};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 fn action_params(token_address: Address, action: TestAction) -> RawBytes {
     RawBytes::serialize(ActionParams { token_address, action }).unwrap()

--- a/testing/integration/tests/transfer_tokens.rs
+++ b/testing/integration/tests/transfer_tokens.rs
@@ -2,10 +2,7 @@ use frc42_dispatch::method_hash;
 use frc46_token::token::{state::TokenState, types::MintReturn};
 use fvm_integration_tests::{dummy::DummyExterns, tester::Account};
 use fvm_ipld_blockstore::MemoryBlockstore;
-use fvm_ipld_encoding::{
-    tuple::{Deserialize_tuple, Serialize_tuple},
-    RawBytes,
-};
+use fvm_ipld_encoding::{tuple::*, RawBytes};
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 

--- a/testing/test_actors/actors/basic_nft_actor/Cargo.toml
+++ b/testing/test_actors/actors/basic_nft_actor/Cargo.toml
@@ -15,7 +15,6 @@ fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 thiserror = { workspace = true }
 
 [lib]

--- a/testing/test_actors/actors/basic_nft_actor/src/lib.rs
+++ b/testing/test_actors/actors/basic_nft_actor/src/lib.rs
@@ -13,12 +13,7 @@ use fvm_actor_utils::{
     blockstore::Blockstore, messaging::FvmMessenger, syscalls::fvm_syscalls::FvmSyscalls,
     util::ActorRuntime,
 };
-use fvm_ipld_encoding::{
-    de::DeserializeOwned,
-    ser,
-    tuple::{Deserialize_tuple, Serialize_tuple},
-    RawBytes, DAG_CBOR,
-};
+use fvm_ipld_encoding::{de::DeserializeOwned, ser, tuple::*, RawBytes, DAG_CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;
 use fvm_shared::error::ExitCode;

--- a/testing/test_actors/actors/basic_token_actor/Cargo.toml
+++ b/testing/test_actors/actors/basic_token_actor/Cargo.toml
@@ -16,7 +16,6 @@ fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 num-traits = { version = "0.2.15" }
 serde = { version = "1.0.136", features = ["derive"] }
-serde_tuple = { version = "0.5.0" }
 thiserror = { version = "1.0.31" }
 
 [lib]

--- a/testing/test_actors/actors/basic_token_actor/src/lib.rs
+++ b/testing/test_actors/actors/basic_token_actor/src/lib.rs
@@ -11,7 +11,7 @@ use frc46_token::token::Token;
 use fvm_actor_utils::blockstore::Blockstore;
 use fvm_actor_utils::syscalls::fvm_syscalls::FvmSyscalls;
 use fvm_actor_utils::util::ActorRuntime;
-use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{RawBytes, DAG_CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::address::Address;

--- a/testing/test_actors/actors/basic_transfer_actor/Cargo.toml
+++ b/testing/test_actors/actors/basic_transfer_actor/Cargo.toml
@@ -16,7 +16,6 @@ fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 multihash-codetable = { workspace = true, features = ["blake2b"] }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/basic_transfer_actor/src/lib.rs
+++ b/testing/test_actors/actors/basic_transfer_actor/src/lib.rs
@@ -5,7 +5,7 @@ use frc46_token::token::types::TransferParams;
 use fvm_actor_utils::receiver::UniversalReceiverParams;
 use fvm_ipld_blockstore::Block;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
+use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::{de::DeserializeOwned, RawBytes, DAG_CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::sys::SendFlags;

--- a/testing/test_actors/actors/frc46_factory_token/Cargo.toml
+++ b/testing/test_actors/actors/frc46_factory_token/Cargo.toml
@@ -14,7 +14,6 @@ fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 thiserror = { workspace = true }
 token_impl = { path = "token_impl" }
 

--- a/testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml
+++ b/testing/test_actors/actors/frc46_factory_token/token_impl/Cargo.toml
@@ -15,6 +15,5 @@ fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 multihash-codetable = { workspace = true, features = ["blake2b"] }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 thiserror = { workspace = true }
 

--- a/testing/test_actors/actors/frc46_factory_token/token_impl/src/lib.rs
+++ b/testing/test_actors/actors/frc46_factory_token/token_impl/src/lib.rs
@@ -17,10 +17,7 @@ use fvm_actor_utils::{
     util::{ActorError, ActorRuntime},
 };
 use fvm_ipld_blockstore::{Block, Blockstore};
-use fvm_ipld_encoding::{
-    tuple::{Deserialize_tuple, Serialize_tuple},
-    CborStore, RawBytes, DAG_CBOR,
-};
+use fvm_ipld_encoding::{tuple::*, CborStore, RawBytes, DAG_CBOR};
 use fvm_sdk::error::{StateReadError, StateUpdateError};
 use fvm_sdk::{self as sdk, sys::ErrorNumber, NO_DATA_BLOCK_ID};
 use fvm_shared::{address::Address, econ::TokenAmount, error::ExitCode, ActorID};

--- a/testing/test_actors/actors/frc46_test_actor/Cargo.toml
+++ b/testing/test_actors/actors/frc46_test_actor/Cargo.toml
@@ -16,7 +16,6 @@ fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/frc46_test_actor/src/lib.rs
+++ b/testing/test_actors/actors/frc46_test_actor/src/lib.rs
@@ -5,11 +5,7 @@ use frc46_token::{
 };
 use fvm_actor_utils::receiver::UniversalReceiverParams;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::{
-    de::DeserializeOwned,
-    tuple::{Deserialize_tuple, Serialize_tuple},
-    RawBytes, DAG_CBOR,
-};
+use fvm_ipld_encoding::{de::DeserializeOwned, tuple::*, RawBytes, DAG_CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::receipt::Receipt;
 use fvm_shared::sys::SendFlags;

--- a/testing/test_actors/actors/frc53_test_actor/Cargo.toml
+++ b/testing/test_actors/actors/frc53_test_actor/Cargo.toml
@@ -16,7 +16,6 @@ fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true }
 fvm_shared = { workspace = true }
 serde = { workspace = true }
-serde_tuple = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"] ## cdylib is necessary for Wasm build

--- a/testing/test_actors/actors/frc53_test_actor/src/lib.rs
+++ b/testing/test_actors/actors/frc53_test_actor/src/lib.rs
@@ -5,11 +5,7 @@ use frc53_nft::types::TokenID;
 use frc53_nft::types::TransferParams;
 use fvm_actor_utils::receiver::UniversalReceiverParams;
 use fvm_ipld_encoding::ipld_block::IpldBlock;
-use fvm_ipld_encoding::{
-    de::DeserializeOwned,
-    tuple::{Deserialize_tuple, Serialize_tuple},
-    RawBytes, DAG_CBOR,
-};
+use fvm_ipld_encoding::{de::DeserializeOwned, tuple::*, RawBytes, DAG_CBOR};
 use fvm_sdk as sdk;
 use fvm_shared::receipt::Receipt;
 use fvm_shared::sys::SendFlags;


### PR DESCRIPTION
This way, the version in `fvm_ipld_encoding` always agrees.