### PR TITLE
Expose frc46_token token state field

### DIFF
--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc46_token"
 description = "Filecoin FRC-0046 fungible token reference implementation"
-version = "14.1.0"
+version = "14.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "frc-0046"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "frc46_token"
 description = "Filecoin FRC-0046 fungible token reference implementation"
-version = "14.0.0"
+version = "14.1.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "frc-0046"]
 repository = "https://github.com/helix-onchain/filecoin/"

--- a/frc46_token/src/token/state.rs
+++ b/frc46_token/src/token/state.rs
@@ -117,7 +117,7 @@ pub struct TokenState {
     /// `balances[owner][operator]`.
     pub allowances: Cid,
     /// Bit-width to use when loading Hamts.
-    hamt_bit_width: u32,
+    pub hamt_bit_width: u32,
 }
 
 /// An abstraction over the IPLD layer to get and modify token state without dealing with HAMTs etc.


### PR DESCRIPTION
This PR changes: 
- Exposes the `hamt_bit_width` in the token state struct 
- Bumped version to `14.1.0` for new release.

### Additional Details
- Forest directly imports the `frc46_token` crate require all the fields for its API `Filecoin.StateReadStateAPI` more info on slack [thread](https://filecoinproject.slack.com/archives/C029LPZ5N73/p1748433101980249?thread_ts=1748430150.870409&cid=C029LPZ5N73)