### PR TITLE
chore(release): prepare crates for ref-fvm 4.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,24 +19,24 @@ members = [
 [workspace.dependencies]
 blake2b_simd = { version = "1.0.3" }
 clap = { version = "4.5.36", features = ["derive"] }
-cid = { version = "0.11.1", default-features = false, features = [
+cid = { version = "0.11.2", default-features = false, features = [
     "serde",
 ] }
-fvm = { version = "~4.8", default-features = false }
-fvm_integration_tests = "~4.8"
+fvm = { version = "~4.8.2", default-features = false }
+fvm_integration_tests = "~4.8.2"
 fvm_ipld_amt = "0.7.6"
 fvm_ipld_bitfield = "0.7.2"
-fvm_ipld_blockstore = "0.3.1"
-fvm_ipld_encoding = "0.5.3"
+fvm_ipld_blockstore = "0.3.2"
+fvm_ipld_encoding = "0.5.4"
 fvm_ipld_hamt = "0.10.5"
-fvm_sdk = "~4.8"
-fvm_shared = "~4.8"
+fvm_sdk = "~4.8.2"
+fvm_shared = "~4.8.2"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = { version = "2.0.12" }
 integer-encoding = { version = "4.0.2" }
 num-traits = { version = "0.2.19" }
 anyhow = { version = "1.0.98" }
-multihash-codetable = { version = "0.1.4", default-features = false }
+multihash-codetable = { version = "0.2.1", default-features = false }
 
 # internal deps of published packages
 frc42_dispatch = { version = "11.0.0", path = "./frc42_dispatch", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "dispatch_examples/greeter",
     "frc42_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ clap = { version = "4.5.36", features = ["derive"] }
 cid = { version = "0.11.1", default-features = false, features = [
     "serde",
 ] }
-fvm = { version = "~4.7", default-features = false }
-fvm_integration_tests = "~4.7"
-fvm_ipld_amt = "0.7.4"
+fvm = { version = "~4.8", default-features = false }
+fvm_integration_tests = "~4.8"
+fvm_ipld_amt = "0.7.6"
 fvm_ipld_bitfield = "0.7.2"
 fvm_ipld_blockstore = "0.3.1"
 fvm_ipld_encoding = "0.5.3"
-fvm_ipld_hamt = "0.10.4"
-fvm_sdk = "~4.7"
-fvm_shared = "~4.7"
+fvm_ipld_hamt = "0.10.5"
+fvm_sdk = "~4.8"
+fvm_shared = "~4.8"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = { version = "2.0.12" }
 integer-encoding = { version = "4.0.2" }
@@ -39,8 +39,8 @@ anyhow = { version = "1.0.98" }
 multihash-codetable = { version = "0.1.4", default-features = false }
 
 # internal deps of published packages
-frc42_dispatch = { version = "10.0.0", path = "./frc42_dispatch", default-features = false }
-fvm_actor_utils = { version = "14.0.0", path = "./fvm_actor_utils" }
+frc42_dispatch = { version = "11.0.0", path = "./frc42_dispatch", default-features = false }
+fvm_actor_utils = { version = "15.0.0", path = "./fvm_actor_utils" }
 
 # only consumed by non-published packages
 frc53_nft = { path = "./frc53_nft" }

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ WASM_EXCLUSION = \
 	--exclude frc46_factory_token \
 	--exclude frc53_test_actor
 
+RUST_TOOLCHAIN = $(shell sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)
+
 ACTORS_VERSION=v15.0.0
 ACTORS_NETWORK=mainnet
 ACTORS_BUNDLE_NAME=builtin-actors-${ACTORS_VERSION}-${ACTORS_NETWORK}.car
@@ -61,7 +63,7 @@ test-actors: test-deps
 	cargo test --package greeter --package helix_integration_tests
 
 install-toolchain:
-	rustup show active-toolchain || rustup toolchain install
+	rustup toolchain install $(RUST_TOOLCHAIN) --component clippy --component rustfmt --target wasm32-unknown-unknown
 
 clean:
 	cargo clean

--- a/frc42_dispatch/Cargo.toml
+++ b/frc42_dispatch/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "frc42_dispatch"
 description = "Filecoin FRC-0042 calling convention/dispatch support library"
-version = "10.0.0"
+version = "11.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "dispatch", "frc-0042"]
 repository = "https://github.com/filecoin-project/actors-utils"
 edition = "2021"
+rust-version = "1.88"
 
 
 [dependencies]
 fvm_ipld_encoding = { workspace = true }
 fvm_sdk = { workspace = true, optional = true }
 fvm_shared = { workspace = true }
-frc42_hasher = { version = "8.0.0", path = "hasher" }
-frc42_macros = { version = "8.0.0", path = "macros" }
+frc42_hasher = { version = "9.0.0", path = "hasher" }
+frc42_macros = { version = "9.0.0", path = "macros" }
 thiserror = { version = "2.0.12" }
 
 [features]

--- a/frc42_dispatch/hasher/Cargo.toml
+++ b/frc42_dispatch/hasher/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "frc42_hasher"
-version = "8.0.0"
+version = "9.0.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention method hashing"
 repository = "https://github.com/filecoin-project/actors-utils"
 edition = "2021"
+rust-version = "1.88"
 
 [dependencies]
 fvm_sdk = { workspace = true, optional = true }

--- a/frc42_dispatch/macros/Cargo.toml
+++ b/frc42_dispatch/macros/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "frc42_macros"
-version = "8.0.0"
+version = "9.0.0"
 license = "MIT OR Apache-2.0"
 description = "Filecoin FRC-0042 calling convention procedural macros"
 repository = "https://github.com/filecoin-project/actors-utils"
 edition = "2021"
+rust-version = "1.88"
 
 [lib]
 proc-macro = true
 
 [dependencies]
 blake2b_simd = { version = "1.0.3" }
-frc42_hasher = { version = "8.0.0", path = "../hasher", default-features = false }
+frc42_hasher = { version = "9.0.0", path = "../hasher", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }

--- a/frc42_dispatch/macros/example/Cargo.toml
+++ b/frc42_dispatch/macros/example/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-frc42_macros = { version = "8.0.0", path = ".." }
+frc42_macros = { version = "9.0.0", path = ".." }

--- a/frc46_token/Cargo.toml
+++ b/frc46_token/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "frc46_token"
 description = "Filecoin FRC-0046 fungible token reference implementation"
-version = "14.1.0"
+version = "15.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "frc-0046"]
 repository = "https://github.com/filecoin-project/actors-utils"
 edition = "2021"
+rust-version = "1.88"
 
 [dependencies]
 frc42_dispatch = { workspace = true }

--- a/frc53_nft/Cargo.toml
+++ b/frc53_nft/Cargo.toml
@@ -2,11 +2,12 @@
 [package]
 name = "frc53_nft"
 description = "Filecoin FRC-0053 non-fungible token reference implementation"
-version = "8.0.0"
+version = "9.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm", "token", "nft", "frc-0053"]
 repository = "https://github.com/filecoin-project/actors-utils"
 edition = "2021"
+rust-version = "1.88"
 
 [dependencies]
 frc42_dispatch = { workspace = true }

--- a/fvm_actor_utils/Cargo.toml
+++ b/fvm_actor_utils/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "fvm_actor_utils"
 description = "Utils for authoring native actors for the Filecoin Virtual Machine"
-version = "14.0.0"
+version = "15.0.0"
 license = "MIT OR Apache-2.0"
 keywords = ["filecoin", "fvm"]
 repository = "https://github.com/filecoin-project/actors-utils"
 edition = "2021"
+rust-version = "1.88"
 
 [dependencies]
 frc42_dispatch = { workspace = true }

--- a/fvm_actor_utils/src/blockstore.rs
+++ b/fvm_actor_utils/src/blockstore.rs
@@ -16,14 +16,14 @@ pub struct Blockstore;
 impl fvm_ipld_blockstore::Blockstore for Blockstore {
     fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
         // If this fails, the _CID_ is invalid. I.e., we have a bug.
-        ipld::get(cid).map(Some).map_err(|e| anyhow!("get failed with {:?} on CID '{}'", e, cid))
+        ipld::get(cid).map(Some).map_err(|e| anyhow!("get failed with {e:?} on CID '{cid}'"))
     }
 
     fn put_keyed(&self, k: &Cid, block: &[u8]) -> Result<()> {
         let code = Code::try_from(k.hash().code()).map_err(|e| anyhow!(e.to_string()))?;
         let k2 = self.put(code, &Block::new(k.codec(), block))?;
         if k != &k2 {
-            return Err(anyhow!("put block with cid {} but has cid {}", k, k2));
+            return Err(anyhow!("put block with cid {k} but has cid {k2}"));
         }
         Ok(())
     }
@@ -36,7 +36,7 @@ impl fvm_ipld_blockstore::Blockstore for Blockstore {
         //  codec at the moment.
         const SIZE: u32 = 32;
         let k = ipld::put(code.into(), SIZE, block.codec, block.data.as_ref())
-            .map_err(|e| anyhow!("put failed with {:?}", e))?;
+            .map_err(|e| anyhow!("put failed with {e:?}"))?;
         Ok(k)
     }
 }

--- a/fvm_dispatch_tools/Cargo.toml
+++ b/fvm_dispatch_tools/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "fvm_dispatch_tools"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
+rust-version = "1.88"
 
 [dependencies]
 blake2b_simd = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.88.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/testing/test_actors/build.rs
+++ b/testing/test_actors/build.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .join("Cargo.toml");
 
     for file in ["Cargo.toml", "src", "actors"] {
-        println!("cargo:rerun-if-changed={}", file);
+        println!("cargo:rerun-if-changed={file}");
     }
 
     // Cargo build command for all actors at once.


### PR DESCRIPTION
## Summary

- bump the workspace FVM dependency line from `~4.7` to `~4.8`
- align the validated IPLD deps used by that line
- prepare the next `actors-utils` crate release family for the `ref-fvm 4.8.x` ecosystem
- pin the repo toolchain to `1.88.0` and add `rust-version = "1.88"` to the publishable crates
- update the local example and Makefile toolchain bootstrap to match

## Why

Forest's `ref-fvm` bump is currently blocked on `actors-utils` still releasing crates against the `4.7.x` line.

This PR prepares the `actors-utils` manifests for a reviewed release on `4.8.x`, without publishing anything yet.

The Rust `1.88.0` pin is hygiene rather than a Forest-specific requirement. Local validation showed the new dependency graph fails on `1.87.x` and succeeds on `1.88.x`, so this makes the repo configuration and published crate metadata reflect the minimum known-good toolchain.

## Validation

- `make install-toolchain`
- `cargo fmt --check`
- `cargo check -p frc42_hasher -p frc42_macros -p frc42_dispatch -p fvm_actor_utils -p frc46_token -p frc53_nft -p fvm_dispatch_tools`
- `cargo test -p frc42_hasher -p frc42_macros -p frc42_dispatch -p fvm_actor_utils -p frc46_token -p frc53_nft -p fvm_dispatch_tools`

## Follow-up

- review and merge this manifest/toolchain prep
- publish the crates in dependency order
- update Forest to the released `actors-utils` versions