### PR TITLE
chore: rm `fvm_dispatch_tools` from the release procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ The following packages are published to [crates.io](https://crates.io):
 - **`frc42_macros`** - FRC-0042 procedural macros
 - **`frc46_token`** - Fungible token reference implementation
 - **`frc53_nft`** - Non-fungible token reference implementation
-- **`fvm_dispatch_tools`** - CLI utilities for method dispatch
 
 #### Release Steps
 
@@ -100,7 +99,6 @@ The following packages are published to [crates.io](https://crates.io):
    # 4. fvm_actor_utils (depends on frc42_dispatch)
    # 5. frc46_token (depends on frc42_dispatch and fvm_actor_utils)
    # 6. frc53_nft (depends on frc42_dispatch and fvm_actor_utils)
-   # 7. fvm_dispatch_tools (depends on frc42_dispatch)
    cargo publish -p <package-name>
    ```
 

--- a/fvm_dispatch_tools/Cargo.toml
+++ b/fvm_dispatch_tools/Cargo.toml
@@ -3,6 +3,7 @@ name = "fvm_dispatch_tools"
 version = "1.1.0"
 edition = "2021"
 rust-version = "1.88"
+publish = false
 
 [dependencies]
 blake2b_simd = { workspace = true }


### PR DESCRIPTION
The crate was never published so I assume nobody is counting on releases on crates.io